### PR TITLE
Display resolved alerts in a separate table

### DIFF
--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -8,3 +8,7 @@
 <script setup>
 import Toast from 'primevue/toast'
 </script>
+
+<style>
+@import '~/assets/css/global.css';
+</style>

--- a/frontend/src/assets/css/global.css
+++ b/frontend/src/assets/css/global.css
@@ -1,0 +1,105 @@
+/* Global Font Size Adjustments for Health Checker Project */
+
+/* PrimeVue DataTable Components */
+.p-datatable {
+    font-size: 0.875rem !important; /* 14px */
+  }
+  
+  .p-datatable .p-datatable-thead > tr > th {
+    font-size: 0.875rem !important; /* 14px */
+  }
+  
+  .p-datatable .p-datatable-tbody > tr > td {
+    font-size: 0.875rem !important; /* 14px */
+  }
+  
+  /* PrimeVue Tags */
+  .p-tag {
+    font-size: 0.75rem !important; /* 12px */
+    padding: 0.25rem 0.5rem !important;
+    border-radius: 0.375rem !important;
+  }
+  
+  /* PrimeVue Buttons */
+  .p-button {
+    font-size: 0.875rem !important; /* 14px */
+    padding: 0.5rem 1rem !important;
+  }
+  
+  /* PrimeVue Cards */
+  .p-card {
+    font-size: 0.875rem !important; /* 14px */
+  }
+  
+  /* Links in tables */
+  .p-datatable a {
+    font-size: 0.875rem !important; /* 14px */
+  }
+  
+  /* Code snippets in tables */
+  .p-datatable pre {
+    font-size: 0.75rem !important; /* 12px */
+  }
+  
+  /* Text utility classes */
+  .text-sm {
+    font-size: 0.875rem !important; /* 14px */
+  }
+  
+  .text-xs {
+    font-size: 0.75rem !important; /* 12px */
+  }
+  
+  /* Font medium class */
+  .font-medium {
+    font-size: 0.875rem !important; /* 14px */
+  }
+  
+  /* Page titles */
+  h1.text-3xl {
+    font-size: 1.75rem !important; /* 28px - reduced from 1.875rem */
+    line-height: 2rem !important;
+  }
+  
+  /* Responsive adjustments */
+  @media (max-width: 768px) {
+    .p-datatable {
+      font-size: 0.8125rem !important; /* 13px */
+    }
+    
+    .p-datatable .p-datatable-thead > tr > th,
+    .p-datatable .p-datatable-tbody > tr > td {
+      font-size: 0.8125rem !important; /* 13px */
+    }
+    
+    .p-button {
+      font-size: 0.8125rem !important; /* 13px */
+    }
+    
+    .p-tag {
+      font-size: 0.6875rem !important; /* 11px */
+    }
+  }
+  
+  @media (max-width: 640px) {
+    .p-datatable {
+      font-size: 0.75rem !important; /* 12px */
+    }
+    
+    .p-datatable .p-datatable-thead > tr > th,
+    .p-datatable .p-datatable-tbody > tr > td {
+      font-size: 0.75rem !important; /* 12px */
+    }
+    
+    .p-button {
+      font-size: 0.75rem !important; /* 12px */
+    }
+    
+    .p-tag {
+      font-size: 0.625rem !important; /* 10px */
+    }
+    
+    .p-datatable pre {
+      font-size: 0.625rem !important; /* 10px */
+    }
+  } 

--- a/frontend/src/components/Molecules/AlertTable.vue
+++ b/frontend/src/components/Molecules/AlertTable.vue
@@ -1,67 +1,90 @@
 <template>
-  <div :class="['alert-table-container', customClass]">
+  <div :class="['w-full overflow-x-auto', customClass]">
     <DataTable 
       :value="alerts" 
-      :class="['p-datatable-sm shadow-md border border-gray-200 rounded-md', tableClass]"
+      :class="[
+        'p-datatable-sm shadow-md border rounded-md',
+        tableClass
+      ]"
       stripedRows 
-      responsiveLayout="scroll" 
+      responsiveLayout="stack"
       sortMode="multiple"
       :loading="loading"
       :empty-message="emptyMessage"
+      scrollable
+      scrollHeight="400px"
+      :resizableColumns="false"
+      columnResizeMode="fit"
     >
-      <Column field="severity" header="Severity" sortable>
+      <Column field="severity" header="Severity" sortable class="col-severity">
         <template #body="slotProps">
           <Tag 
             :value="slotProps.data.severity" 
             :severity="getSeverityColor(slotProps.data.severity)" 
+            data-label="Severity"
           />
         </template>
       </Column>
       
-      <Column field="checkType" header="Type" sortable>
+      <Column field="checkType" header="Type" sortable class="col-check-type">
         <template #body="slotProps">
-          {{ getCheckTypeLabel(slotProps.data.checkType) }}
+          <div class="text-sm" data-label="Type">
+            {{ getCheckTypeLabel(slotProps.data.checkType) }}
+          </div>
         </template>
       </Column>
       
-      <Column field="title" header="Title" sortable />
-      <Column field="description" header="Description" />
+      <Column field="title" header="Title" sortable class="col-title">
+        <template #body="slotProps">
+          <div class="font-medium text-gray-900 truncate" :title="slotProps.data.title" data-label="Title">
+            {{ slotProps.data.title || '-' }}
+          </div>
+        </template>
+      </Column>
       
-      <Column field="filePath" header="File (Line)">
+      <Column field="description" header="Description" class="col-description">
+        <template #body="slotProps">
+          <div class="text-sm text-gray-700 truncate" :title="slotProps.data.description" data-label="Description">
+            {{ slotProps.data.description || '-' }}
+          </div>
+        </template>
+      </Column>
+      
+      <Column field="filePath" header="File (Line)" class="col-file-path">
         <template #body="slotProps">
           <a 
             v-if="slotProps.data.filePath && slotProps.data.lineNumber"
             :href="getFileUrl(slotProps.data.filePath, slotProps.data.lineNumber, slotProps.data.branch)"
-            class="text-blue-600 underline hover:text-blue-800" 
+            class="file-link truncate block text-blue-600 hover:text-blue-800 hover:underline transition-colors duration-200" 
             target="_blank" 
             rel="noopener noreferrer"
             :aria-label="`View ${slotProps.data.filePath} at line ${slotProps.data.lineNumber} on GitHub`"
+            :title="`${slotProps.data.filePath}:${slotProps.data.lineNumber}`"
+            data-label="File (Line)"
           >
             {{ slotProps.data.filePath }}:{{ slotProps.data.lineNumber }}
           </a>
-          <span v-else>-</span>
+          <span v-else class="text-gray-500" data-label="File (Line)">-</span>
         </template>
       </Column>
       
-      <Column field="codeSnippet" header="Code">
+      <Column field="codeSnippet" header="Code" class="col-code">
         <template #body="slotProps">
-          <pre class="whitespace-pre-wrap text-sm text-gray-700 max-w-xs overflow-x-auto">
-            {{ slotProps.data.codeSnippet || '-' }}
-          </pre>
+          <pre class="code-snippet font-mono text-xs text-gray-700 bg-gray-50 p-2 rounded border max-h-24 overflow-y-auto whitespace-pre-wrap" data-label="Code">{{ slotProps.data.codeSnippet }}</pre>
         </template>
       </Column>
       
-      <Column field="note" header="Note">
+      <Column field="note" header="Note" class="col-note">
         <template #body="slotProps">
-          <span class="text-sm text-gray-800 whitespace-pre-wrap">
-            {{ formatNotes(slotProps.data.notes) }}
-          </span>
+          <pre class="note-content text-sm text-gray-800 whitespace-pre-wrap max-h-20 overflow-y-auto" v-html="formatNotes(slotProps.data.notes)" data-label="Note" />
         </template>
       </Column>
       
-      <Column field="lastDetectedAt" header="Last Detected" sortable>
+      <Column field="lastDetectedAt" header="Last Detected" sortable class="col-last-detected">
         <template #body="slotProps">
-          {{ formatDate(slotProps.data.lastDetectedAt) }}
+          <div class="text-sm text-gray-600" data-label="Last Detected">
+            {{ formatDate(slotProps.data.lastDetectedAt) }}
+          </div>
         </template>
       </Column>
     </DataTable>
@@ -69,7 +92,6 @@
 </template>
 
 <script setup>
-// Log Review URL: https://58llm.link/main/restore/31cd93c9-e937-4957-8ced-a4beedf7c283
 import DataTable from 'primevue/datatable'
 import Column from 'primevue/column'
 import Tag from 'primevue/tag'
@@ -111,6 +133,11 @@ const props = defineProps({
     default: '',
   },
   tableClass: {
+    type: String,
+    required: false,
+    default: '',
+  },
+  tableType: {
     type: String,
     required: false,
     default: '',
@@ -159,7 +186,244 @@ const formatNotes = (notes) => {
 </script>
 
 <style scoped>
-.alert-table-container {
-  min-height: 200px;
+/* Column width classes for perfect alignment */
+:deep(.col-severity) {
+  width: 80px !important;
+  min-width: 80px !important;
+  max-width: 80px !important;
+}
+
+:deep(.col-check-type) {
+  width: 150px !important;
+  min-width: 150px !important;
+  max-width: 150px !important;
+}
+
+:deep(.col-title) {
+  width: 150px !important;
+  min-width: 150px !important;
+  max-width: 150px !important;
+}
+
+:deep(.col-description) {
+  width: 300px !important;
+  min-width: 300px !important;
+  max-width: 300px !important;
+}
+
+:deep(.col-file-path) {
+  width: 200px !important;
+  min-width: 200px !important;
+  max-width: 200px !important;
+  white-space: normal !important;
+  word-break: break-all !important;
+  overflow-wrap: break-word !important;
+}
+
+:deep(.col-file-path .p-datatable-tbody > tr > td) {
+  white-space: normal !important;
+  word-break: break-all !important;
+  overflow-wrap: break-word !important;
+  overflow: visible !important;
+  text-overflow: unset !important;
+}
+
+:deep(.col-code) {
+  width: 200px !important;
+  min-width: 200px !important;
+  max-width: 200px !important;
+}
+
+:deep(.col-note) {
+  width: 280px !important;
+  min-width: 280px !important;
+  max-width: 280px !important;
+}
+
+:deep(.col-last-detected) {
+  width: 110px !important;
+  min-width: 110px !important;
+  max-width: 110px !important;
+}
+
+/* Ensure consistent table layout with fixed columns */
+:deep(.p-datatable) {
+  width: 100%;
+  table-layout: fixed;
+  min-width: 1470px; /* Total width: 80+150+150+300+200+200+280+110 = 1470px */
+}
+
+:deep(.p-datatable .p-datatable-thead > tr > th) {
+  padding: 0.5rem;
+  text-align: left;
+  white-space: nowrap;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+}
+
+:deep(.p-datatable .p-datatable-tbody > tr > td) {
+  padding: 0.5rem;
+  vertical-align: middle;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+/* Ensure inner elements are properly aligned */
+:deep(.p-datatable .p-datatable-tbody > tr > td > div),
+:deep(.p-datatable .p-datatable-tbody > tr > td > span),
+:deep(.p-datatable .p-datatable-tbody > tr > td > a) {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+}
+
+/* Consistent link styling */
+:deep(.p-datatable a) {
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+:deep(.p-datatable a:hover) {
+  text-decoration: underline;
+}
+
+/* File link specific styling */
+:deep(.file-link) {
+  text-decoration: none;
+  transition: color 0.2s ease;
+  font-size: 0.875rem;
+  word-break: break-all;
+  overflow-wrap: break-word;
+}
+
+:deep(.file-link:hover) {
+  text-decoration: underline;
+}
+
+/* Code snippet styling */
+:deep(.code-snippet) {
+  margin: 0;
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+  line-height: 1.4;
+  text-align: left;
+  text-indent: 0;
+  padding: 0.25rem;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  font-size: 0.75rem;
+  max-height: 100px;
+  overflow-y: auto;
+}
+
+/* Note content styling */
+:deep(.note-content) {
+  font-size: 0.875rem;
+  white-space: pre-wrap;
+  max-height: 80px;
+  overflow-y: auto;
+  line-height: 1.4;
+}
+
+/* Text styling */
+:deep(.p-datatable .text-sm) {
+  font-size: 0.875rem;
+}
+
+:deep(.p-datatable .text-xs) {
+  font-size: 0.75rem;
+}
+
+:deep(.p-datatable .font-medium) {
+  font-weight: 500;
+}
+
+/* Responsive breakpoints */
+@media (max-width: 1024px) {
+  :deep(.p-datatable) {
+    min-width: 1470px;
+  }
+  
+  :deep(.p-datatable .p-datatable-thead > tr > th),
+  :deep(.p-datatable .p-datatable-tbody > tr > td) {
+    padding: 0.5rem;
+  }
+}
+
+@media (max-width: 768px) {
+  :deep(.p-datatable) {
+    min-width: 1470px;
+  }
+  
+  :deep(.p-datatable .p-datatable-thead > tr > th),
+  :deep(.p-datatable .p-datatable-tbody > tr > td) {
+    padding: 0.375rem;
+  }
+}
+
+@media (max-width: 640px) {
+  :deep(.p-datatable) {
+    min-width: 1470px;
+  }
+  
+  :deep(.p-datatable .p-datatable-thead > tr > th),
+  :deep(.p-datatable .p-datatable-tbody > tr > td) {
+    padding: 0.25rem;
+  }
+  
+  :deep(.code-snippet) {
+    padding: 0.25rem;
+    font-size: 0.7rem;
+  }
+}
+
+/* Stack layout for very small screens */
+@media (max-width: 480px) {
+  :deep(.p-datatable) {
+    min-width: auto;
+    table-layout: auto;
+  }
+  
+  :deep(.p-datatable .p-datatable-thead > tr > th),
+  :deep(.p-datatable .p-datatable-tbody > tr > td) {
+    display: block;
+    width: 100%;
+    padding: 0.5rem;
+  }
+  
+  :deep(.p-datatable .p-datatable-tbody > tr > td:before) {
+    content: attr(data-label) ": ";
+    font-weight: 600;
+    display: inline-block;
+    width: 120px;
+  }
+  
+  :deep(.code-snippet) {
+    margin-top: 0.5rem;
+  }
+}
+
+/* Hover effects */
+:deep(.p-datatable .p-datatable-tbody > tr:hover) {
+  /* Keep original hover behavior */
+}
+
+/* Loading state */
+:deep(.p-datatable.p-datatable-loading) {
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+/* Empty state */
+:deep(.p-datatable .p-datatable-emptymessage) {
+  padding: 2rem;
+  text-align: center;
 }
 </style>

--- a/frontend/src/composables/useAlerts.ts
+++ b/frontend/src/composables/useAlerts.ts
@@ -28,7 +28,13 @@ export function useAlerts(owner: Ref<string | null>, repo: Ref<string | null>) {
     alerts.value.filter((a) => !a.isIgnored && !a.systemResolved)
   )
 
+  const resolvedAlerts = computed(() =>
+    alerts.value.filter((a) => !a.isIgnored && a.systemResolved)
+  )
+
   const hasAlerts = computed(() => visibleAlerts.value.length > 0)
+
+  const hasResolvedAlerts = computed(() => resolvedAlerts.value.length > 0)
 
   const alertCounts = computed(() => {
     const counts = { high: 0, middle: 0, low: 0 }
@@ -157,7 +163,9 @@ export function useAlerts(owner: Ref<string | null>, repo: Ref<string | null>) {
     
     // Computed
     visibleAlerts,
+    resolvedAlerts,
     hasAlerts,
+    hasResolvedAlerts,
     alertCounts,
     
     // Utility functions

--- a/frontend/src/pages/[...slug].vue
+++ b/frontend/src/pages/[...slug].vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="p-6 space-y-6">
+  <div class="p-6 space-y-8">
     <HealthTitle title="GitHub Health Checker" />
 
     <BackToDashboardLink />
@@ -8,15 +8,55 @@
 
     <LoadingText v-if="loading" text="Loading alerts..." aria-label="Loading alert data" />
 
-    <AlertTable 
-      v-else
-      :alerts="visibleAlerts"
-      :checkTypeLabels="checkTypeLabels"
-      :owner="owner"
-      :repo="repo"
-      :loading="loading"
-      empty-message="No alerts found for this repository."
-    />
+    <!-- Unresolved Alerts Section -->
+    <div v-else-if="hasAlerts" class="space-y-4">
+      <div class="p-4">
+        <h2 class="text-xl font-bold text-red-800">
+          Active Alerts ({{ visibleAlerts.length }})
+        </h2>
+        <p class="text-sm text-red-600 mt-1">Issues that require immediate attention</p>
+      </div>
+      
+      <AlertTable 
+        :alerts="visibleAlerts"
+        :checkTypeLabels="checkTypeLabels"
+        :owner="owner"
+        :repo="repo"
+        :loading="loading"
+        empty-message="No active alerts found for this repository."
+        table-type="active"
+        custom-class="shadow-lg"
+      />
+    </div>
+
+    <!-- Resolved Alerts Section -->
+    <div v-if="!loading && hasResolvedAlerts" class="space-y-4">
+      <div class="p-4">
+        <h2 class="text-xl font-bold text-green-800">
+          Resolved Alerts ({{ resolvedAlerts.length }})
+        </h2>
+        <p class="text-sm text-green-600 mt-1">Issues that have been automatically resolved</p>
+      </div>
+      
+      <AlertTable 
+        :alerts="resolvedAlerts"
+        :checkTypeLabels="checkTypeLabels"
+        :owner="owner"
+        :repo="repo"
+        :loading="false"
+        empty-message="No resolved alerts found for this repository."
+        table-type="resolved"
+        custom-class="shadow-lg"
+      />
+    </div>
+
+    <!-- No Alerts Message -->
+    <div v-if="!loading && !hasAlerts && !hasResolvedAlerts" class="text-center py-12">
+      <div class="max-w-md mx-auto">
+        <h3 class="text-lg font-medium text-gray-900 mb-2">No Alerts Found</h3>
+        <p class="text-gray-500">This repository appears to be healthy with no active or resolved alerts.</p>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -43,7 +83,10 @@ const {
   error,
   visibleAlerts,
   checkTypeLabels,
-  fetchAlerts
+  fetchAlerts,
+  resolvedAlerts,
+  hasAlerts,
+  hasResolvedAlerts
 } = useAlerts(owner, repo)
 
 // Watch for route changes and refetch alerts
@@ -70,6 +113,33 @@ onMounted(() => {
 .back-link:visited {
   color: white !important;
   text-decoration: none;
+}
+
+/* Ensure title styling is applied - only for section titles, not table headers */
+h2.text-red-800 {
+  color: #991b1b !important;
+  font-weight: 700 !important;
+  font-size: 1.25rem !important;
+  line-height: 1.75rem !important;
+}
+
+h2.text-green-800 {
+  color: #166534 !important;
+  font-weight: 700 !important;
+  font-size: 1.25rem !important;
+  line-height: 1.75rem !important;
+}
+
+p.text-red-600 {
+  color: #dc2626 !important;
+  font-size: 0.875rem !important;
+  line-height: 1.25rem !important;
+}
+
+p.text-green-600 {
+  color: #16a34a !important;
+  font-size: 0.875rem !important;
+  line-height: 1.25rem !important;
 }
 </style>
   


### PR DESCRIPTION
## Note  (if necessary)
- Record the NOTES and requirements related to the order of merging PRs or any necessary configurations.

## Description
- Display resolved alerts in a separate table
[#8](https://github.com/TeckVeho/health-checker/issues/8)
- The current DataTable continues to display only unresolved alerts.
- A new DataTable is added to display resolved alerts (systemResolved is true).
- Each table has a clear section title to distinguish between unresolved and resolved alerts.

## AI log URL

- alertTable.vue: https://58llm.link/main/restore/dc778408-c37c-45b2-94ea-3b9f58bd6afc
- alert screen: https://58llm.link/main/restore/745d0a7c-90e7-4866-9ea0-cd42c9316b4b

## Evidence
![image](https://github.com/user-attachments/assets/c2748907-9e08-4edf-9ae7-d49cab6223d9)

![image](https://github.com/user-attachments/assets/30401484-5118-41f3-8378-177c9ef04be4)

![image](https://github.com/user-attachments/assets/c137d308-082b-44bd-a107-28151fd73346)

![image](https://github.com/user-attachments/assets/98f90568-7444-4081-9154-66cd6f4d8b40)

![image](https://github.com/user-attachments/assets/7a7033f0-1868-439a-979c-a488660b9a1b)