### PR TITLE
refactor checkbranches to return structured alerts instead of writinh

### DIFF
--- a/backend/src/domain/alert/alertService.ts
+++ b/backend/src/domain/alert/alertService.ts
@@ -1,12 +1,11 @@
-
 import Repo from '../repo/repoModel';
 import { cloneRepo } from './util/cloneRepo';
 import { gitleaksScanner } from './util/gitleaksScanner';
-import { checkBranches } from './util/checkBranches';
+import { checkBranches, type AlertCandidate } from './util/checkBranches';
 import sequelize from '../../config/database';
 import { QueryTypes, Op } from 'sequelize';
 import Alert from './alertModel';
-import { subDays } from 'date-fns'; 
+import { subDays, format } from 'date-fns';
 
 class AlertService {
   static async getAlertsByRepo(owner: string, repo: string) {
@@ -105,6 +104,95 @@ class AlertService {
 
     return summary;
   }
+  static async processBranchAlerts(owner: string, repo: string): Promise<{ owner: string; repo: string }> {
+    const timestamp = new Date();
+    const result = await checkBranches(owner, repo);
+    const detectedKeySet = new Set<string>();
+
+    // Process new alerts
+    for (const alert of result.alerts) {
+      const key = [alert.owner, alert.repo, alert.checkType, alert.title, alert.filePath, alert.lineNumber, alert.codeSnippet, alert.branch].join('||');
+      detectedKeySet.add(key);
+
+      await Alert.findOrCreate({
+        where: { 
+          owner: alert.owner, 
+          repo: alert.repo, 
+          checkType: alert.checkType, 
+          title: alert.title, 
+          filePath: alert.filePath, 
+          lineNumber: alert.lineNumber, 
+          codeSnippet: alert.codeSnippet, 
+          branch: alert.branch 
+        },
+        defaults: {
+          owner: alert.owner,
+          repo: alert.repo,
+          checkType: alert.checkType,
+          title: alert.title,
+          description: alert.description,
+          severity: alert.severity,
+          filePath: alert.filePath,
+          lineNumber: alert.lineNumber,
+          codeSnippet: alert.codeSnippet,
+          branch: alert.branch,
+          detectCount: 1,
+          lastDetectedAt: timestamp,
+          isIgnored: false,
+          manualResolved: false,
+          systemResolved: false,
+          createdAt: timestamp,
+        },
+      }).then(async ([record, created]) => {
+        if (!created) {
+          await record.update({
+            detectCount: record.detectCount + 1,
+            lastDetectedAt: timestamp,
+            systemResolved: false,
+            systemResolvedReason: undefined,
+          });
+        }
+      });
+    }
+
+    // Resolve old alerts that are no longer detected
+    const existing = await Alert.findAll({
+      where: {
+        owner,
+        repo,
+        checkType: ['branch_name_violation', 'branch_protect_rule_violation', 'default_branch_violation'],
+        systemResolved: false,
+      },
+    });
+
+    const resolveTimestamp = format(new Date(), 'yyyyMMddHHmmss');
+
+    for (const row of existing) {
+      const key = [
+        row.getDataValue('owner'), 
+        row.getDataValue('repo'), 
+        row.getDataValue('checkType'), 
+        row.getDataValue('title'), 
+        row.getDataValue('filePath') ?? '', 
+        row.getDataValue('lineNumber') ?? -1, 
+        row.getDataValue('codeSnippet') ?? '', 
+        row.getDataValue('branch') ?? ''
+      ].join('||');
+
+      if (!detectedKeySet.has(key)) {
+        console.log(`🛠 Resolving: ${key}`);
+        await row.update({
+          systemResolved: true,
+          systemResolvedReason: `${resolveTimestamp}:Automatically resolved: not detected`,
+        });
+      } else {
+        console.log(`✅ Still active: ${key}`);
+      }
+    }
+
+    return { owner, repo };
+  }
+
   static async runAlert(options: { owner: string; repo: string; checks?: string[] }): Promise<Record<string, unknown>> {
     const { owner, repo, checks } = options;
     const effectiveChecks = checks ?? ['branch', 'clone', 'gitleaks'];
@@ -116,7 +204,7 @@ class AlertService {
     }
 
     if (effectiveChecks.includes('branch')) {
-      await checkBranches(owner, repo);
+      await this.processBranchAlerts(owner, repo);
       results.branch = 'checked';
     }
 

--- a/backend/src/domain/alert/util/checkBranches.ts
+++ b/backend/src/domain/alert/util/checkBranches.ts
@@ -1,6 +1,4 @@
 import { Octokit } from '@octokit/rest';
-import { format } from 'date-fns';
-import Alert from '../alertModel';
 
 const githubToken = process.env.GITHUB_API_KEY;
 if (!githubToken) throw new Error('GITHUB_API_KEY is required');
@@ -9,12 +7,30 @@ const octokit = new Octokit({ auth: githubToken });
 
 const BRANCHES = ['develop', 'staging', 'production'];
 
-export async function checkBranches(owner: string, repo: string): Promise<{ owner: string; repo: string }> {
-  const timestamp = new Date();
+export interface AlertCandidate {
+  owner: string;
+  repo: string;
+  checkType: string;
+  title: string;
+  description: string;
+  severity: string;
+  filePath: string;
+  lineNumber: number;
+  codeSnippet: string;
+  branch: string;
+}
+
+export interface CheckBranchesResult {
+  owner: string;
+  repo: string;
+  alerts: AlertCandidate[];
+}
+
+export async function checkBranches(owner: string, repo: string): Promise<CheckBranchesResult> {
+  const alerts: AlertCandidate[] = [];
   const filePath = '';
   const lineNumber = -1;
   const codeSnippet = '';
-  const detectedKeySet = new Set<string>();
 
   let defaultBranch = 'main';
   try {
@@ -29,40 +45,19 @@ export async function checkBranches(owner: string, repo: string): Promise<{ owne
     const title = `default-branch:${defaultBranch}`;
     const description = `Default branch is '${defaultBranch}', but expected 'develop'.`;
     const branch = defaultBranch;
-    const key = [owner, repo, checkType, title, filePath, lineNumber, codeSnippet, branch].join('||');
 
-    await Alert.findOrCreate({
-      where: { owner, repo, checkType, title, filePath, lineNumber, codeSnippet, branch },
-      defaults: {
-        owner,
-        repo,
-        checkType,
-        title,
-        filePath,
-        lineNumber,
-        codeSnippet,
-        branch,
-        description,
-        severity: 'high',
-        detectCount: 1,
-        lastDetectedAt: timestamp,
-        isIgnored: false,
-        manualResolved: false,
-        systemResolved: false,
-        createdAt: timestamp,
-      },
-    }).then(async ([record, created]) => {
-      if (!created) {
-        await record.update({
-          detectCount: record.detectCount + 1,
-          lastDetectedAt: timestamp,
-          systemResolved: false,
-          systemResolvedReason: undefined,
-        });
-      }
+    alerts.push({
+      owner,
+      repo,
+      checkType,
+      title,
+      description,
+      severity: 'high',
+      filePath,
+      lineNumber,
+      codeSnippet,
+      branch,
     });
-
-    detectedKeySet.add(key);
   }
 
   for (const branch of BRANCHES) {
@@ -82,41 +77,20 @@ export async function checkBranches(owner: string, repo: string): Promise<{ owne
       const checkType = 'branch_name_violation';
       const title = `branch:${branch}`;
       const description = `Branch '${branch}' does not exist.`;
-      const key = [owner, repo, checkType, title, filePath, lineNumber, codeSnippet, branch].join('||');
-      console.log(`🚨 Detected: ${key}`);
+      console.log(`🚨 Detected: ${checkType}:${title}`);
 
-      await Alert.findOrCreate({
-        where: { owner, repo, checkType, title, filePath, lineNumber, codeSnippet, branch },
-        defaults: {
-          owner,
-          repo,
-          checkType,
-          title,
-          filePath,
-          lineNumber,
-          codeSnippet,
-          branch,
-          description,
-          severity,
-          detectCount: 1,
-          lastDetectedAt: timestamp,
-          isIgnored: false,
-          manualResolved: false,
-          systemResolved: false,
-          createdAt: timestamp,
-        },
-      }).then(async ([record, created]) => {
-        if (!created) {
-          await record.update({
-            detectCount: record.detectCount + 1,
-            lastDetectedAt: timestamp,
-            systemResolved: false,
-            systemResolvedReason: undefined,
-          });
-        }
+      alerts.push({
+        owner,
+        repo,
+        checkType,
+        title,
+        description,
+        severity,
+        filePath,
+        lineNumber,
+        codeSnippet,
+        branch,
       });
-
-      detectedKeySet.add(key);
       continue;
     }
 
@@ -179,70 +153,24 @@ export async function checkBranches(owner: string, repo: string): Promise<{ owne
       const checkType = 'branch_protect_rule_violation';
       const title = `branch-unprotected:${branch}`;
       const description = `Branch '${branch}' exists but is not protected.`;
-      const key = [owner, repo, checkType, title, filePath, lineNumber, codeSnippet, branch].join('||');
-      console.log(`🚨 Detected: ${key}`);
+      console.log(`🚨 Detected: ${checkType}:${title}`);
 
-      await Alert.findOrCreate({
-        where: { owner, repo, checkType, title, filePath, lineNumber, codeSnippet, branch },
-        defaults: {
-          owner,
-          repo,
-          checkType,
-          title,
-          filePath,
-          lineNumber,
-          codeSnippet,
-          branch,
-          description,
-          severity,
-          detectCount: 1,
-          lastDetectedAt: timestamp,
-          isIgnored: false,
-          manualResolved: false,
-          systemResolved: false,
-          createdAt: timestamp,
-        },
-      }).then(async ([record, created]) => {
-        if (!created) {
-          await record.update({
-            detectCount: record.detectCount + 1,
-            lastDetectedAt: timestamp,
-            systemResolved: false,
-            systemResolvedReason: undefined,
-          });
-        }
+      alerts.push({
+        owner,
+        repo,
+        checkType,
+        title,
+        description,
+        severity,
+        filePath,
+        lineNumber,
+        codeSnippet,
+        branch,
       });
-
-      detectedKeySet.add(key);
     }
   }
 
-  console.log(`🧾 detectedKeySet: ${JSON.stringify([...detectedKeySet], null, 2)}`);
+  console.log(`🧾 Found ${alerts.length} alerts for ${owner}/${repo}`);
 
-  const existing = await Alert.findAll({
-    where: {
-      owner,
-      repo,
-      checkType: ['branch_name_violation', 'branch_protect_rule_violation', 'default_branch_violation'],
-      systemResolved: false,
-    },
-  });
-
-  const resolveTimestamp = format(new Date(), 'yyyyMMddHHmmss');
-
-  for (const row of existing) {
-    const key = [row.getDataValue('owner'), row.getDataValue('repo'), row.getDataValue('checkType'), row.getDataValue('title'), row.getDataValue('filePath') ?? '', row.getDataValue('lineNumber') ?? -1, row.getDataValue('codeSnippet') ?? '', row.getDataValue('branch') ?? ''].join('||');
-
-    if (!detectedKeySet.has(key)) {
-      console.log(`🛠 Resolving: ${key}`);
-      await row.update({
-        systemResolved: true,
-        systemResolvedReason: `${resolveTimestamp}:Automatically resolved: not detected`,
-      });
-    } else {
-      console.log(`✅ Still active: ${key}`);
-    }
-  }
-
-  return { owner, repo };
+  return { owner, repo, alerts };
 }


### PR DESCRIPTION

## Description
- Refactor checkBranches.ts to remove all DB operations

- Move alert DB operations to alertService.ts

- Ensure checkBranches is unit-testable without DB dependencies

## AI log URL
- https://58llm.link/main/restore/b73aa4e5-5921-4cdb-91cc-7841090516c6

- https://58llm.link/main/restore/476ac709-83b0-495d-86ef-95e2f2f56101

## Evidence
- 
![image](https://github.com/user-attachments/assets/18919267-0ea8-44f5-80a3-fc1033a40273)
![image](https://github.com/user-attachments/assets/15fad10f-35c0-4727-a75c-f4f67747a1d1)
![image](https://github.com/user-attachments/assets/1d106e23-269d-4512-bf29-e48fccca078c)
