### PR TITLE
Display and enable sorting of GitHub repo description

### DIFF
--- a/frontend/src/components/Molecules/RepoTable.vue
+++ b/frontend/src/components/Molecules/RepoTable.vue
@@ -25,6 +25,14 @@
         </template>
       </Column>
       
+      <Column field="description" header="Description" sortable>
+        <template #body="slotProps">
+          <div class="text-white max-w-xs truncate" :title="slotProps.data.description">
+            {{ slotProps.data.description || '-' }}
+          </div>
+        </template>
+      </Column>
+      
       <Column field="totalViolations" header="Total" sortable>
         <template #body="slotProps">
           <HealthTag 

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -13,6 +13,7 @@ export interface Repo {
   id: string
   owner: string
   name: string
+  description?: string
   lastActivityAt: string
   [key: string]: any
 }
@@ -193,7 +194,7 @@ export class ApiService {
   }
 
   private validateSort(sort: string): string {
-    const validSorts = ['last_activity_at', 'name', 'owner', 'created_at']
+    const validSorts = ['last_activity_at', 'name', 'owner', 'created_at', 'description']
     if (!validSorts.includes(sort)) {
       throw createAppError.validation(errorMessages.VALIDATION.INVALID_SORT(validSorts), { sort, validSorts })
     }

--- a/frontend/tests/unit/components/Molecules/RepoTable.spec.ts
+++ b/frontend/tests/unit/components/Molecules/RepoTable.spec.ts
@@ -8,6 +8,7 @@ describe('RepoTable Logic', () => {
   const createMockRepoData = (overrides: any = {}) => ({
     name: 'test-repo',
     owner: 'test-owner',
+    description: 'A test repository for testing purposes',
     totalViolations: 5,
     high: 2,
     middle: 2,
@@ -63,6 +64,22 @@ describe('RepoTable Logic', () => {
       expect(repoWithMissingFields.owner).toBe('test-owner')
       expect(repoWithMissingFields.totalViolations).toBeUndefined()
       expect(repoWithMissingFields.high).toBeUndefined()
+    })
+
+    it('should handle repositories with description field', () => {
+      const repoWithDescription = createMockRepoData({
+        description: 'A detailed description of the repository'
+      })
+
+      expect(repoWithDescription.description).toBe('A detailed description of the repository')
+    })
+
+    it('should handle repositories without description', () => {
+      const repoWithoutDescription = createMockRepoData({
+        description: undefined
+      })
+
+      expect(repoWithoutDescription.description).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
## Note  (if necessary)
- Record the NOTES and requirements related to the order of merging PRs or any necessary configurations.

## Description

- Display and enable sorting of GitHub repo description [#35](https://github.com/TeckVeho/health-checker/issues/35)
- Add description to Repo interface
- Display description column in the repository list
- Enable sorting by description on the frontend
- Verify 

## AI log URL

- RepoTable.vue: https://58llm.link/main/restore/7dca6a0d-5391-4207-a325-21c1d4f400d6
- RepoTable.spec.ts: https://58llm.link/main/restore/37907205-270c-4fc6-ad0f-f50e7a513ff3

## Evidence
![image](https://github.com/user-attachments/assets/d5d9ffe1-11c0-49cf-a7ba-eb62627fa43f)
![image](https://github.com/user-attachments/assets/00f593d5-8431-48a9-ae91-f813b46a3b07)
