### PR TITLE
update add ui switch view

### DIFF
--- a/frontend/src/composables/useAlerts.ts
+++ b/frontend/src/composables/useAlerts.ts
@@ -48,96 +48,6 @@ export function useAlerts(owner: Ref<string | null>, repo: Ref<string | null>) {
     return counts
   })
 
-  // Health summary data
-  const health = ref<{
-    total: number
-    high: number
-    middle: number
-    low: number
-  }>({
-    total: 0,
-    high: 0,
-    middle: 0,
-    low: 0
-  })
-
-  const healthTableData = ref<Array<{
-    severity: string
-    count: number
-    percentage: number
-    tagSeverity: string | null
-    isTotal: boolean
-  }>>([])
-
-  const healthColumns = [
-    { label: 'High', key: 'high', tagSeverity: 'danger' },
-    { label: 'Middle', key: 'middle', tagSeverity: 'warning' },
-    { label: 'Low', key: 'low', tagSeverity: 'info' },
-  ]
-
-  // Prepare table data for DataTable
-  const prepareHealthTableData = () => {
-    const data = []
-    
-    // Add severity rows
-    healthColumns.forEach(col => {
-      data.push({
-        severity: col.label,
-        count: (health.value as any)[col.key] || 0,
-        percentage: health.value.total > 0 ? Math.round(((health.value as any)[col.key] || 0) / health.value.total * 100) : 0,
-        tagSeverity: col.tagSeverity,
-        isTotal: false
-      })
-    })
-    
-    // Add total row
-    data.push({
-      severity: 'Total',
-      count: health.value.total,
-      percentage: 100,
-      tagSeverity: null,
-      isTotal: true
-    })
-    
-    healthTableData.value = data
-  }
-
-  // Fetch health summary data
-  const fetchHealthSummary = async (): Promise<void> => {
-    if (!validateParams()) {
-      return
-    }
-
-    try {
-      const summaryData = await callApi(
-        () => apiService.getAlertSummary([{ owner: owner.value!, repo: repo.value! }]),
-        { errorMessage: 'Failed to fetch alert summary' }
-      )
-
-      if (summaryData) {
-        const healthData = `${owner.value}/${repo.value}`
-        let total = 0
-        
-        for (const col of healthColumns) {
-          const val = summaryData[healthData]?.[col.key as keyof typeof summaryData[typeof healthData]] ?? 0
-          total += val
-        }
-        
-        health.value = {
-          total: total,
-          high: summaryData[healthData]?.['high'] ?? 0,
-          middle: summaryData[healthData]?.['middle'] ?? 0,
-          low: summaryData[healthData]?.['low'] ?? 0,
-        }
-        
-        prepareHealthTableData()
-      }
-    } catch (err) {
-      console.error('Error fetching health summary:', err)
-      toast.error('Failed to Load Health Summary', 'Unable to fetch health summary data')
-    }
-  }
-
   // Validation helpers
   const validateParams = (): boolean => {
     if (!owner.value || !repo.value) {
@@ -254,12 +164,6 @@ export function useAlerts(owner: Ref<string | null>, repo: Ref<string | null>) {
     hasAlerts,
     hasResolvedAlerts,
     alertCounts,
-    
-    // Health summary
-    health: readonly(health),
-    healthTableData: readonly(healthTableData),
-    healthColumns,
-    fetchHealthSummary,
     
     // Utility functions
     formatDate,

--- a/frontend/src/composables/useCheckTypeAlerts.ts
+++ b/frontend/src/composables/useCheckTypeAlerts.ts
@@ -1,0 +1,118 @@
+import { computed, watch } from 'vue'
+import { useCheckTypeSortState } from './useCheckTypeSortState'
+import { useFilterState } from './useFilterState'
+import { useSharedState } from './useSharedState'
+import { CHECK_TYPE_COLUMNS } from '../constants/table'
+
+export function useCheckTypeAlerts() {
+  const { sortState, updateSortState } = useCheckTypeSortState()
+  const { filterState, updateShowOnlyActive, toggleShowOnlyActive } = useFilterState()
+  const sharedState = useSharedState()
+
+  // Update threshold when showOnlyActive changes
+  const updateThreshold = () => {
+    sharedState.updateThreshold(filterState.value.showOnlyActive)
+  }
+
+  // Watch for changes in showOnlyActive to update threshold
+  watch(() => filterState.value.showOnlyActive, updateThreshold, { immediate: true })
+
+  const tableData = computed(() => {
+    // Show all repositories, not just those with alerts
+    return sharedState.repos.value.map((repo) => {
+      const fullName = `${repo.owner}/${repo.name}`
+      const summaryData = sharedState.alertSummaryByCheckType.value[fullName] || {}
+
+      const row = { ...repo }
+      let total = 0
+      
+      // Map check type data to columns
+      CHECK_TYPE_COLUMNS.forEach((col) => {
+        (row as any)[col.key] = summaryData[col.key] || 0
+        total += (row as any)[col.key] || 0
+      })
+      
+      // Calculate total
+      row.totalViolations = total
+      return row
+    })
+  })
+
+  const filteredTableData = computed(() => {
+    if (!filterState.value.showOnlyActive) return tableData.value
+
+    // Use cached threshold date
+    if (!sharedState.thresholdDate.value) {
+      updateThreshold()
+    }
+
+    return tableData.value.filter((repo) => {
+      const lastActivity = new Date(repo.lastActivityAt)
+      return !isNaN(lastActivity.getTime()) && lastActivity >= sharedState.thresholdDate.value!
+    })
+  })
+
+  const sortedTableData = computed(() => {
+    const data = [...filteredTableData.value]
+    const { field, order } = sortState.value
+
+    if (!field) return data
+
+    data.sort((a, b) => {
+      let aVal = a[field]
+      let bVal = b[field]
+
+      // Handle date sorting
+      if (field === 'lastActivityAt' || field === 'createdAt') {
+        aVal = aVal ? new Date(aVal).getTime() : 0
+        bVal = bVal ? new Date(bVal).getTime() : 0
+      }
+
+      // Handle numeric sorting for violation counts
+      if (['totalViolations', ...CHECK_TYPE_COLUMNS.map(col => col.key)].includes(field)) {
+        aVal = Number(aVal) || 0
+        bVal = Number(bVal) || 0
+      }
+
+      // Handle string sorting
+      if (typeof aVal === 'string' && typeof bVal === 'string') {
+        aVal = aVal.toLowerCase()
+        bVal = bVal.toLowerCase()
+      }
+
+      if (aVal < bVal) return order === 'asc' ? -1 : 1
+      if (aVal > bVal) return order === 'asc' ? 1 : -1
+      return 0
+    })
+
+    return data
+  })
+
+
+
+  async function fetchData() {
+    const currentField = sortState.value.field
+    const backendField = sharedState.mapFieldToBackend(currentField)
+    
+    await sharedState.fetchRepos(backendField)
+    await sharedState.fetchAlertSummaryByCheckType()
+  }
+
+  return {
+    columns: CHECK_TYPE_COLUMNS,
+    repos: sharedState.repos,
+    reposWithAlerts: sharedState.repos, // Changed to show all repos
+    alertSummary: sharedState.alertSummaryByCheckType,
+    showOnlyActive: computed(() => filterState.value.showOnlyActive),
+    tableData,
+    filteredTableData,
+    sortedTableData,
+    loading: sharedState.loading,
+    error: sharedState.error,
+    fetchData,
+    sortState,
+    updateSortState,
+    updateShowOnlyActive,
+    toggleShowOnlyActive,
+  }
+} 

--- a/frontend/src/composables/useCheckTypeSortState.ts
+++ b/frontend/src/composables/useCheckTypeSortState.ts
@@ -1,0 +1,69 @@
+import { ref, watch, readonly, onMounted } from 'vue'
+
+interface SortState {
+  field: string
+  order: 'asc' | 'desc'
+}
+
+const STORAGE_KEY = 'checktype-table-sort-state'
+
+export function useCheckTypeSortState() {
+  const sortState = ref<SortState>({ field: 'lastActivityAt', order: 'desc' })
+
+  // Initialize sort state from localStorage or use default
+  const getInitialSortState = (): SortState => {
+    // Only access localStorage on client side
+    if (typeof window !== 'undefined' && window.localStorage) {
+      try {
+        const stored = localStorage.getItem(STORAGE_KEY)
+        if (stored) {
+          const parsed = JSON.parse(stored) as SortState
+          return parsed
+        }
+      } catch (error) {
+        console.warn('Failed to parse stored checkType sort state:', error)
+      }
+    }
+    const defaultState = { field: 'lastActivityAt', order: 'desc' } as SortState
+    return defaultState
+  }
+
+  // Load sort state from localStorage after mount
+  onMounted(() => {
+    const storedState = getInitialSortState()
+    sortState.value = storedState
+  })
+
+  // Save sort state to localStorage whenever it changes
+  const saveSortState = (state: SortState) => {
+    // Only access localStorage on client side
+    if (typeof window !== 'undefined' && window.localStorage) {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+      } catch (error) {
+        console.warn('Failed to save checkType sort state:', error)
+      }
+    }
+  }
+
+  // Watch for changes and save to localStorage
+  watch(sortState, (newState) => {
+    saveSortState(newState)
+  }, { deep: true })
+
+  // Update sort state
+  const updateSortState = (field: string, order: 'asc' | 'desc') => {
+    sortState.value = { field, order }
+  }
+
+  // Clear sort state (reset to default)
+  const clearSortState = () => {
+    sortState.value = { field: 'lastActivityAt', order: 'desc' }
+  }
+
+  return {
+    sortState: readonly(sortState),
+    updateSortState,
+    clearSortState,
+  }
+} 

--- a/frontend/src/composables/useRepoHealth.ts
+++ b/frontend/src/composables/useRepoHealth.ts
@@ -1,50 +1,27 @@
-import { ref, computed, watch } from 'vue'
-import { apiService, type Repo, type AlertSummary } from '~/utils/api'
-import { useApi } from './useApi'
-import { useApiConfig } from './useApiConfig'
+import { computed, watch } from 'vue'
 import { useSortState } from './useSortState'
 import { useFilterState } from './useFilterState'
-
-const columns = [
-  { label: 'High', key: 'high', tagSeverity: 'danger' },
-  { label: 'Middle', key: 'middle', tagSeverity: 'warning' },
-  { label: 'Low', key: 'low', tagSeverity: 'info' },
-]
+import { useSharedState } from './useSharedState'
+import { SEVERITY_COLUMNS } from '../constants/table'
 
 export function useRepoHealth() {
-  const { loading, error, callApi } = useApi()
-  const { apiBaseUrl } = useApiConfig()
   const { sortState, updateSortState } = useSortState()
   const { filterState, updateShowOnlyActive, toggleShowOnlyActive } = useFilterState()
+  const sharedState = useSharedState()
 
-  // Initialize API service with correct base URL
-  apiService.init(apiBaseUrl)
-
-  const repos = ref<Repo[]>([])
-  const health = ref<AlertSummary>({})
-  
-  // Cache the threshold date to avoid redundant computations
-  const thresholdDate = ref<Date | null>(null)
-  
   // Update threshold when showOnlyActive changes
   const updateThreshold = () => {
-    if (filterState.value.showOnlyActive) {
-      const threshold = new Date()
-      threshold.setDate(threshold.getDate() - 14)
-      thresholdDate.value = threshold
-    } else {
-      thresholdDate.value = null
-    }
+    sharedState.updateThreshold(filterState.value.showOnlyActive)
   }
 
   const tableData = computed(() =>
-    repos.value.map((repo) => {
+    sharedState.repos.value.map((repo) => {
       const fullName = `${repo.owner}/${repo.name}`
-      const healthData = health.value[fullName] || {}
+      const healthData = sharedState.alertSummary.value[fullName] || {}
 
       const row = { ...repo }
       let total = 0
-      for (const col of columns) {
+      for (const col of SEVERITY_COLUMNS) {
         const val = (healthData as any)[col.key] ?? 0
         row[col.key] = val
         total += val
@@ -61,13 +38,13 @@ export function useRepoHealth() {
     if (!filterState.value.showOnlyActive) return tableData.value
 
     // Use cached threshold date
-    if (!thresholdDate.value) {
+    if (!sharedState.thresholdDate.value) {
       updateThreshold()
     }
 
     return tableData.value.filter((repo) => {
       const lastActivity = new Date(repo.lastActivityAt)
-      return !isNaN(lastActivity.getTime()) && lastActivity >= thresholdDate.value!
+      return !isNaN(lastActivity.getTime()) && lastActivity >= sharedState.thresholdDate.value!
     })
   })
 
@@ -106,57 +83,24 @@ export function useRepoHealth() {
     })
   })
 
-  // Map frontend field names to backend field names
-  const mapFieldToBackend = (field: string): string => {
-    const fieldMap: Record<string, string> = {
-      'lastActivityAt': 'last_activity_at',
-      'name': 'name',
-      'owner': 'owner',
-      'description': 'description',
-      'createdAt': 'created_at',
-      // For computed fields like totalViolations, high, middle, low, we don't send to backend
-      // These will be sorted on the frontend only
-    }
-    return fieldMap[field] || 'last_activity_at' // default fallback
-  }
-
   async function fetchData() {
-    // Only send backend-sortable fields to the API
     const currentField = sortState.value.field
-    const backendField = mapFieldToBackend(currentField)
+    const backendField = sharedState.mapFieldToBackend(currentField)
     
-    const repoData = await callApi(
-      () => apiService.getRepos(200, backendField),
-      { errorMessage: 'Failed to fetch repositories' }
-    )
-    
-    if (repoData) {
-      repos.value = repoData
-
-      // Fetch alert summary
-      const summaryData = await callApi(
-        () => apiService.getAlertSummary(
-          repos.value.map((r) => ({ owner: r.owner, repo: r.name }))
-        ),
-        { errorMessage: 'Failed to fetch alert summary' }
-      )
-      
-      if (summaryData) {
-        health.value = summaryData
-      }
-    }
+    await sharedState.fetchRepos(backendField)
+    await sharedState.fetchAlertSummary()
   }
 
   return {
-    columns,
-    repos,
-    health,
+    columns: SEVERITY_COLUMNS,
+    repos: sharedState.repos,
+    health: sharedState.alertSummary,
     showOnlyActive: computed(() => filterState.value.showOnlyActive),
     tableData,
     filteredTableData,
     sortedTableData,
-    loading,
-    error,
+    loading: sharedState.loading,
+    error: sharedState.error,
     fetchData,
     sortState,
     updateSortState,

--- a/frontend/src/composables/useSharedState.ts
+++ b/frontend/src/composables/useSharedState.ts
@@ -1,0 +1,156 @@
+import { ref, computed, readonly } from 'vue'
+import { apiService, type Repo, type AlertSummary } from '~/utils/api'
+import { useApi } from './useApi'
+import { useApiConfig } from './useApiConfig'
+import { FIELD_MAPPING, TABLE_CONFIG, FILTER_THRESHOLD_DAYS } from '../constants/table'
+
+// Shared state singleton
+let sharedStateInstance: ReturnType<typeof createSharedState> | null = null
+
+function createSharedState() {
+  const { callApi } = useApi()
+  const { apiBaseUrl } = useApiConfig()
+
+  // Initialize API service with correct base URL
+  apiService.init(apiBaseUrl)
+
+  // Shared repositories data
+  const repos = ref<Repo[]>([])
+  const alertSummary = ref<AlertSummary>({})
+  const alertSummaryByCheckType = ref<AlertSummary>({})
+  
+  // Loading states
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  // Cache the threshold date to avoid redundant computations
+  const thresholdDate = ref<Date | null>(null)
+
+  // Computed properties
+  const reposWithAlerts = computed(() => {
+    return repos.value.filter((repo) => {
+      const fullName = `${repo.owner}/${repo.name}`
+      const summaryData = alertSummary.value[fullName]
+      return summaryData && Object.keys(summaryData).length > 0
+    })
+  })
+
+  // Update threshold when showOnlyActive changes
+  const updateThreshold = (showOnlyActive: boolean) => {
+    if (showOnlyActive) {
+      const threshold = new Date()
+      threshold.setDate(threshold.getDate() - FILTER_THRESHOLD_DAYS)
+      thresholdDate.value = threshold
+    } else {
+      thresholdDate.value = null
+    }
+  }
+
+  // Map frontend field names to backend field names
+  const mapFieldToBackend = (field: string): string => {
+    return FIELD_MAPPING[field as keyof typeof FIELD_MAPPING] || 'last_activity_at'
+  }
+
+  // Fetch repositories data
+  const fetchRepos = async (sortField: string = TABLE_CONFIG.sortField): Promise<void> => {
+    if (loading.value) return // Prevent duplicate calls
+
+    try {
+      loading.value = true
+      error.value = null
+
+      const backendField = mapFieldToBackend(sortField)
+      
+      const repoData = await callApi(
+        () => apiService.getRepos(TABLE_CONFIG.defaultLimit, backendField),
+        { errorMessage: 'Failed to fetch repositories' }
+      )
+      
+      if (repoData) {
+        repos.value = repoData
+      }
+    } catch (err) {
+      console.error('Error fetching repos:', err)
+      error.value = 'Failed to fetch repositories'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  // Fetch alert summary data
+  const fetchAlertSummary = async (): Promise<void> => {
+    if (repos.value.length === 0) return
+
+    try {
+      const summaryData = await callApi(
+        () => apiService.getAlertSummary(
+          repos.value.map((r) => ({ owner: r.owner, repo: r.name }))
+        ),
+        { errorMessage: 'Failed to fetch alert summary' }
+      )
+      
+      if (summaryData) {
+        alertSummary.value = summaryData
+      }
+    } catch (err) {
+      console.error('Error fetching alert summary:', err)
+      error.value = 'Failed to fetch alert summary'
+    }
+  }
+
+  // Fetch alert summary by check type data
+  const fetchAlertSummaryByCheckType = async (): Promise<void> => {
+    if (repos.value.length === 0) return
+
+    try {
+      const summaryData = await callApi(
+        () => apiService.getAlertSummaryByCheckType(
+          repos.value.map((r) => ({ owner: r.owner, repo: r.name }))
+        ),
+        { errorMessage: 'Failed to fetch alert summary by check type' }
+      )
+      
+      if (summaryData) {
+        alertSummaryByCheckType.value = summaryData
+      }
+    } catch (err) {
+      console.error('Error fetching alert summary by check type:', err)
+      error.value = 'Failed to fetch alert summary by check type'
+    }
+  }
+
+  // Initialize data (called once)
+  const initializeData = async (sortField: string = TABLE_CONFIG.sortField): Promise<void> => {
+    await fetchRepos(sortField)
+    await fetchAlertSummary()
+    await fetchAlertSummaryByCheckType()
+  }
+
+  return {
+    // State
+    repos: readonly(repos),
+    alertSummary: readonly(alertSummary),
+    alertSummaryByCheckType: readonly(alertSummaryByCheckType),
+    loading: readonly(loading),
+    error: readonly(error),
+    thresholdDate: readonly(thresholdDate),
+
+    // Computed
+    reposWithAlerts,
+
+    // Actions
+    updateThreshold,
+    fetchRepos,
+    fetchAlertSummary,
+    fetchAlertSummaryByCheckType,
+    initializeData,
+    mapFieldToBackend,
+  }
+}
+
+export function useSharedState() {
+  if (!sharedStateInstance) {
+    sharedStateInstance = createSharedState()
+  }
+  return sharedStateInstance
+} 

--- a/frontend/src/composables/useTabState.ts
+++ b/frontend/src/composables/useTabState.ts
@@ -1,0 +1,64 @@
+import { ref, watch, readonly, onMounted } from 'vue'
+
+type TabValue = 'severity' | 'checkType'
+
+const STORAGE_KEY = 'health-checker-active-tab'
+
+export function useTabState() {
+  const activeTab = ref<TabValue>('severity')
+
+  // Initialize tab state from localStorage or use default
+  const getInitialTabState = (): TabValue => {
+    // Only access localStorage on client side
+    if (typeof window !== 'undefined' && window.localStorage) {
+      try {
+        const stored = localStorage.getItem(STORAGE_KEY)
+        if (stored && (stored === 'severity' || stored === 'checkType')) {
+          return stored as TabValue
+        }
+      } catch (error) {
+        console.warn('Failed to parse stored tab state:', error)
+      }
+    }
+    return 'severity' as TabValue
+  }
+
+  // Load tab state from localStorage after mount
+  onMounted(() => {
+    const storedTab = getInitialTabState()
+    activeTab.value = storedTab
+  })
+
+  // Save tab state to localStorage whenever it changes
+  const saveTabState = (tab: TabValue) => {
+    // Only access localStorage on client side
+    if (typeof window !== 'undefined' && window.localStorage) {
+      try {
+        localStorage.setItem(STORAGE_KEY, tab)
+      } catch (error) {
+        console.warn('Failed to save tab state:', error)
+      }
+    }
+  }
+
+  // Watch for changes and save to localStorage
+  watch(activeTab, (newTab) => {
+    saveTabState(newTab)
+  })
+
+  // Update active tab
+  const setActiveTab = (tab: TabValue) => {
+    activeTab.value = tab
+  }
+
+  // Get current active tab
+  const getActiveTab = (): TabValue => {
+    return activeTab.value
+  }
+
+  return {
+    activeTab: readonly(activeTab),
+    setActiveTab,
+    getActiveTab,
+  }
+} 

--- a/frontend/src/constants/table.ts
+++ b/frontend/src/constants/table.ts
@@ -1,0 +1,66 @@
+// Table column definitions
+export const SEVERITY_COLUMNS = [
+  { label: 'High', key: 'high', tagSeverity: 'danger' },
+  { label: 'Middle', key: 'middle', tagSeverity: 'warning' },
+  { label: 'Low', key: 'low', tagSeverity: 'info' },
+] as const
+
+// Check Type Columns based on checkTypeLabels
+export const CHECK_TYPE_COLUMNS = [
+  { label: 'Default Branch Violation', key: 'default_branch_violation', tagSeverity: 'danger' },
+  { label: 'Branch Name Violation', key: 'branch_name_violation', tagSeverity: 'warning' },
+  { label: 'Branch Protect Rule Violation', key: 'branch_protect_rule_violation', tagSeverity: 'danger' },
+  { label: 'Exposed Secret Key', key: 'exposed_secret_key', tagSeverity: 'danger' },
+  { label: 'Issue Format Violation', key: 'issue_format_violation', tagSeverity: 'warning' },
+  { label: 'Pull Request Format Violation', key: 'pull_request_format_violation', tagSeverity: 'warning' },
+  { label: 'No Unit Test CI', key: 'no_unit_test_ci', tagSeverity: 'info' },
+  { label: 'Security Risk', key: 'security_risk', tagSeverity: 'danger' },
+  { label: 'Performance Issue', key: 'performance_issue', tagSeverity: 'warning' },
+] as const
+
+// Field mapping for backend sorting
+export const FIELD_MAPPING = {
+  'lastActivityAt': 'last_activity_at',
+  'name': 'name',
+  'owner': 'owner',
+  'description': 'description',
+  'createdAt': 'created_at',
+} as const
+
+// Numeric fields for sorting
+export const NUMERIC_FIELDS = [
+  'totalViolations',
+  'high',
+  'middle',
+  'low'
+] as const
+
+// Date fields for sorting
+export const DATE_FIELDS = [
+  'lastActivityAt',
+  'createdAt'
+] as const
+
+// String fields for sorting
+export const STRING_FIELDS = [
+  'name',
+  'owner',
+  'description'
+] as const
+
+// Default sort configuration
+export const DEFAULT_SORT = {
+  field: 'lastActivityAt',
+  order: 'desc' as const
+}
+
+// Filter threshold (days)
+export const FILTER_THRESHOLD_DAYS = 14
+
+// Table configuration
+export const TABLE_CONFIG = {
+  defaultLimit: 200,
+  sortField: 'last_activity_at',
+  retryAttempts: 3,
+  retryDelay: 1000,
+} as const 

--- a/frontend/src/pages/[...slug].vue
+++ b/frontend/src/pages/[...slug].vue
@@ -5,88 +5,57 @@
     <BackToDashboardLink />
 
     <RepoAlertTitle :owner="owner" :repo="repo" />
-    <Tabs value="severity">
-      <TabList>
-        <Tab value="severity">Severity-based view</Tab>
-        <Tab value="checkType">CheckType-based view</Tab>
-      </TabList>
-      <TabPanels>
-        <TabPanel value="severity">
-          <LoadingText v-if="loading" text="Loading alerts..." aria-label="Loading alert data" />
+    
+    <LoadingText v-if="loading" text="Loading alerts..." aria-label="Loading alert data" />
 
-          <!-- Unresolved Alerts Section -->
-          <div v-else-if="hasAlerts" class="space-y-4">
-            <SectionHeader 
-              title="Active Alerts"
-              :count="visibleAlerts.length"
-              description="Issues that require immediate attention"
-              variant="active"
-            />
-            
-            <AlertTable 
-              :alerts="visibleAlerts"
-              :checkTypeLabels="checkTypeLabels"
-              :owner="owner"
-              :repo="repo"
-              :loading="loading"
-              empty-message="No active alerts found for this repository."
-              table-type="active"
-              custom-class="shadow-lg"
-            />
-          </div>
+    <!-- Unresolved Alerts Section -->
+    <div v-else-if="hasAlerts" class="space-y-4">
+      <SectionHeader 
+        title="Active Alerts"
+        :count="visibleAlerts.length"
+        description="Issues that require immediate attention"
+        variant="active"
+      />
+      
+      <AlertTable 
+        :alerts="visibleAlerts"
+        :checkTypeLabels="checkTypeLabels"
+        :owner="owner"
+        :repo="repo"
+        :loading="loading"
+        empty-message="No active alerts found for this repository."
+        table-type="active"
+        custom-class="shadow-lg"
+      />
+    </div>
 
-          <!-- Resolved Alerts Section -->
-          <div v-if="!loading && hasResolvedAlerts" class="space-y-4">
-            <SectionHeader 
-              title="Resolved Alerts"
-              :count="resolvedAlerts.length"
-              description="Issues that have been automatically resolved"
-              variant="resolved"
-            />
-            
-            <AlertTable 
-              :alerts="resolvedAlerts"
-              :checkTypeLabels="checkTypeLabels"
-              :owner="owner"
-              :repo="repo"
-              :loading="false"
-              empty-message="No resolved alerts found for this repository."
-              table-type="resolved"
-              custom-class="shadow-lg"
-            />
-          </div>
+    <!-- Resolved Alerts Section -->
+    <div v-if="!loading && hasResolvedAlerts" class="space-y-4">
+      <SectionHeader 
+        title="Resolved Alerts"
+        :count="resolvedAlerts.length"
+        description="Issues that have been automatically resolved"
+        variant="resolved"
+      />
+      
+      <AlertTable 
+        :alerts="resolvedAlerts"
+        :checkTypeLabels="checkTypeLabels"
+        :owner="owner"
+        :repo="repo"
+        :loading="false"
+        empty-message="No resolved alerts found for this repository."
+        table-type="resolved"
+        custom-class="shadow-lg"
+      />
+    </div>
 
-          <!-- No Alerts Message -->
-          <EmptyState 
-            v-if="!loading && !hasAlerts && !hasResolvedAlerts"
-            title="No Alerts Found"
-            description="This repository appears to be healthy with no active or resolved alerts."
-          />
-        </TabPanel>
-        <TabPanel value="checkType">
-          <div class="space-y-6">
-            <!-- Health Summary Table -->
-            <HealthSummaryCard 
-              v-if="health.total > 0"
-              title="Health Summary"
-              description="Repository health overview by severity"
-            >
-              <HealthSummaryTable 
-                :tableData="healthTableData"
-                empty-message="No health data available"
-              />
-            </HealthSummaryCard>
-
-            <!-- No Health Data Message -->
-            <EmptyState 
-              v-else
-              title="No Health Data Available"
-              description="Health summary data is not available for this repository."
-            />
-          </div>
-        </TabPanel>
-      </TabPanels>
-    </Tabs>
+    <!-- No Alerts Message -->
+    <EmptyState 
+      v-if="!loading && !hasAlerts && !hasResolvedAlerts"
+      title="No Alerts Found"
+      description="This repository appears to be healthy with no active or resolved alerts."
+    />
   </div>
 </template>
 
@@ -99,8 +68,6 @@ import BackToDashboardLink from '~/components/Atoms/BackToDashboardLink.vue'
 import LoadingText from '~/components/Atoms/LoadingText.vue'
 import RepoAlertTitle from '~/components/Atoms/RepoAlertTitle.vue'
 import SectionHeader from '~/components/Molecules/SectionHeader.vue'
-import HealthSummaryCard from '~/components/Molecules/HealthSummaryCard.vue'
-import HealthSummaryTable from '~/components/Molecules/HealthSummaryTable.vue'
 import EmptyState from '~/components/Atoms/EmptyState.vue'
 import { useRouteParams } from '~/composables/useRouteParams'
 import { useAlerts } from '~/composables/useAlerts'
@@ -121,17 +88,12 @@ const {
   resolvedAlerts,
   hasAlerts,
   hasResolvedAlerts,
-  health,
-  healthTableData,
-  healthColumns,
-  fetchHealthSummary
 } = useAlerts(owner, repo)
 // Watch for route changes and refetch alerts
 watch([owner, repo], async ([newOwner, newRepo]) => {
   if (newOwner && newRepo) {
     try {
       await fetchAlerts()
-      await fetchHealthSummary()
     } catch (err) {
       console.error('Error fetching alerts on route change:', err)
       toast.error('Navigation Error', 'Failed to load alerts for the new repository')

--- a/frontend/src/pages/index.vue
+++ b/frontend/src/pages/index.vue
@@ -5,34 +5,70 @@
         <!-- Filter Card -->
         <RepoFilterCard
             :showOnlyActive="showOnlyActive"
-            :loading="loading"
+            :loading="loading || checkTypeLoading"
             @toggle-active="handleToggleFilter"
         />
 
-        <!-- Loading -->
-        <div v-if="repos.length === 0">
-            <LoadingText 
-                text="Loading repositories..."
-                aria-label="Loading repository data"
-            />
-        </div>
+        <Tabs :value="activeTab" @update:value="handleTabChange">
+          <TabList>
+            <Tab value="severity">Severity-based view</Tab>
+            <Tab value="checkType">CheckType-based view</Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel value="severity">
+              <!-- Loading -->
+              <div v-if="repos.length === 0">
+                <LoadingText 
+                  text="Loading repositories..."
+                  aria-label="Loading repository data"
+                />
+              </div>
 
-        <!-- Repo Table -->
-        <div v-else>
-            <RepoTable 
-                :tableData="sortedTableData" 
-                :columns="columns"
-                :loading="loading"
-                :sortState="sortState"
-                @sort-change="handleSortChange"
-                empty-message="No repositories found. Try adjusting your filters."
-            />
-        </div>
+              <!-- Repo Table -->
+              <div v-else>
+                <RepoTable 
+                  :tableData="sortedTableData" 
+                  :columns="columns"
+                  :loading="loading"
+                  :sortState="sortState"
+                  @sort-change="handleSortChange"
+                  empty-message="No repositories found. Try adjusting your filters."
+                />
+              </div>
+            </TabPanel>
+            <TabPanel value="checkType">
+              <!-- Loading -->
+              <div v-if="repos.length === 0">
+                <LoadingText 
+                  text="Loading checkType data..."
+                  aria-label="Loading checkType data"
+                />
+              </div>
+
+              <!-- CheckType Repo Table -->
+              <div v-else>
+                <RepoTable 
+                  :tableData="checkTypeSortedTableData" 
+                  :columns="checkTypeColumns"
+                  :loading="checkTypeLoading"
+                  :sortState="checkTypeSortState"
+                  @sort-change="handleCheckTypeSortChange"
+                  empty-message="No repositories found. Try adjusting your filters."
+                />
+              </div>
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+
     </div>
 </template>
 
 <script setup>
+import { onMounted } from 'vue'
 import { useRepoHealth } from '@/composables/useRepoHealth'
+import { useCheckTypeAlerts } from '@/composables/useCheckTypeAlerts'
+import { useTabState } from '@/composables/useTabState'
+import { useSharedState } from '@/composables/useSharedState'
 import { useCustomToast } from '@/composables/useCustomToast'
 import HealthTitle from '@/components/Atoms/HealthTitle.vue'
 import HealthButton from '@/components/Atoms/HealthButton.vue'
@@ -42,6 +78,11 @@ import RepoFilterCard from '@/components/Molecules/RepoFilterCard.vue'
 import RepoTable from '@/components/Molecules/RepoTable.vue'
 
 const toast = useCustomToast()
+
+// Tab state management
+const { activeTab, setActiveTab } = useTabState()
+
+// Severity-based data
 const {
   columns,
   repos,
@@ -54,17 +95,40 @@ const {
   loading,
 } = useRepoHealth()
 
+// CheckType-based data
+const {
+  columns: checkTypeColumns,
+  repos: checkTypeRepos,
+  sortedTableData: checkTypeSortedTableData,
+  sortState: checkTypeSortState,
+  updateSortState: updateCheckTypeSortState,
+  toggleShowOnlyActive: toggleCheckTypeShowOnlyActive,
+  fetchData: fetchCheckTypeData,
+  loading: checkTypeLoading,
+} = useCheckTypeAlerts()
+
 const handleSortChange = (field, order) => {
   updateSortState(field, order)
 }
 
+const handleCheckTypeSortChange = (field, order) => {
+  updateCheckTypeSortState(field, order)
+}
+
+const handleTabChange = (tab) => {
+  setActiveTab(tab)
+}
+
 const handleToggleFilter = () => {
   toggleShowOnlyActive()
+  toggleCheckTypeShowOnlyActive()
 }
 
 async function fetchAndToast() {
   try {
-    await fetchData()
+    // Use shared state to avoid duplicate API calls
+    const sharedState = useSharedState()
+    await sharedState.initializeData()
   } catch (err) {
     toast.error('Error fetching data', err?.message || String(err))
   }

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -20,9 +20,7 @@ export interface Repo {
 
 export interface AlertSummary {
   [repoKey: string]: {
-    high: number
-    middle: number
-    low: number
+    [key: string]: number
   }
 }
 
@@ -231,6 +229,22 @@ export class ApiService {
       logError(error, 'getAlertSummary')
       const context: ErrorContext = { operation: 'fetch alert summary', reposCount: repos.length }
       throw createAppError.api(errorMessages.API.FETCH_FAILED('alert summary'), context)
+    }
+  }
+
+  // Alert methods
+  async getAlertSummaryByCheckType(repos: Array<{ owner: string; repo: string }>): Promise<AlertSummary> {
+    try {
+      if (!Array.isArray(repos) || repos.length === 0) {
+        throw createAppError.validation(errorMessages.VALIDATION.EMPTY_ARRAY, { repos })
+      }
+      
+      const response = await this.client.post<AlertSummary>('/api/alerts/summary-by-checktype', repos)
+      return response.data
+    } catch (error) {
+      logError(error, 'getAlertSummaryByCheckType')
+      const context: ErrorContext = { operation: 'fetch alert summary by check type', reposCount: repos.length }
+      throw createAppError.api(errorMessages.API.FETCH_FAILED('alert summary by check type'), context)
     }
   }
 

--- a/frontend/tests/unit/composables/useAlerts.spec.ts
+++ b/frontend/tests/unit/composables/useAlerts.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { useAlerts } from '@/composables/useAlerts'
+import { useAlerts } from '~/composables/useAlerts'
 import { ref, type Ref } from 'vue'
 import type { Alert } from '@/types/alerts'
 
@@ -12,7 +12,7 @@ vi.mock('@/utils/api', () => ({
   }
 }))
 
-vi.mock('@/composables/useApi', () => ({
+vi.mock('~/composables/useApi', () => ({
   useApi: vi.fn(() => ({ 
     callApi: vi.fn((fn) => fn()),
     loading: ref(false),
@@ -20,11 +20,11 @@ vi.mock('@/composables/useApi', () => ({
   }))
 }))
 
-vi.mock('@/composables/useApiConfig', () => ({
+vi.mock('~/composables/useApiConfig', () => ({
   useApiConfig: vi.fn(() => ({ apiBaseUrl: 'http://localhost:3000' }))
 }))
 
-vi.mock('@/composables/useCustomToast', () => ({
+vi.mock('~/composables/useCustomToast', () => ({
   useCustomToast: vi.fn(() => ({ error: vi.fn() }))
 }))
 
@@ -106,17 +106,7 @@ describe('useAlerts', () => {
       })
     })
 
-    it('should have empty health data initially', () => {
-      const result = useAlerts(owner, repo)
-      
-      expect(result.health.value).toEqual({
-        total: 0,
-        high: 0,
-        middle: 0,
-        low: 0
-      })
-      expect(result.healthTableData.value).toEqual([])
-    })
+
   })
 
   describe('utility functions', () => {
@@ -218,74 +208,5 @@ describe('useAlerts', () => {
     })
   })
 
-  describe('health summary functionality', () => {
-    it('should return expected health properties', () => {
-      const result = useAlerts(owner, repo)
-      
-      expect(result).toHaveProperty('health')
-      expect(result).toHaveProperty('healthTableData')
-      expect(result).toHaveProperty('healthColumns')
-      expect(result).toHaveProperty('fetchHealthSummary')
-    })
 
-    it('should have correct health columns configuration', () => {
-      const result = useAlerts(owner, repo)
-      
-      expect(result.healthColumns).toEqual([
-        { label: 'High', key: 'high', tagSeverity: 'danger' },
-        { label: 'Middle', key: 'middle', tagSeverity: 'warning' },
-        { label: 'Low', key: 'low', tagSeverity: 'info' }
-      ])
-    })
-
-    it('should test health table data structure', () => {
-      const healthColumns = [
-        { label: 'High', key: 'high', tagSeverity: 'danger' },
-        { label: 'Middle', key: 'middle', tagSeverity: 'warning' },
-        { label: 'Low', key: 'low', tagSeverity: 'info' }
-      ]
-      
-      const health = { total: 3, high: 1, middle: 1, low: 1 }
-      
-      const tableData: Array<{
-        severity: string
-        count: number
-        percentage: number
-        tagSeverity: string | null
-        isTotal: boolean
-      }> = healthColumns.map(col => ({
-        severity: col.label,
-        count: health[col.key as keyof typeof health] || 0,
-        percentage: health.total > 0 ? 
-          Math.round((health[col.key as keyof typeof health] || 0) / health.total * 100) : 0,
-        tagSeverity: col.tagSeverity,
-        isTotal: false
-      }))
-      
-      // Add total row
-      tableData.push({
-        severity: 'Total',
-        count: health.total,
-        percentage: 100,
-        tagSeverity: null,
-        isTotal: true
-      })
-      
-      expect(tableData).toHaveLength(4) // 3 severity levels + 1 total
-      expect(tableData[0]).toEqual({
-        severity: 'High',
-        count: 1,
-        percentage: 33,
-        tagSeverity: 'danger',
-        isTotal: false
-      })
-      expect(tableData[3]).toEqual({
-        severity: 'Total',
-        count: 3,
-        percentage: 100,
-        tagSeverity: null,
-        isTotal: true
-      })
-    })
-  })
 }) 

--- a/frontend/tests/unit/composables/useApi.spec.ts
+++ b/frontend/tests/unit/composables/useApi.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { useApi } from '@/composables/useApi'
+import { useApi } from '~/composables/useApi'
 
 // Mock dependencies
 vi.mock('@/utils/api', () => ({

--- a/frontend/tests/unit/composables/useCheckTypeAlerts.spec.ts
+++ b/frontend/tests/unit/composables/useCheckTypeAlerts.spec.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useCheckTypeAlerts } from '@/composables/useCheckTypeAlerts'
+
+// Mock all the composables to avoid Nuxt runtime dependencies
+vi.mock('@/composables/useSharedState', () => ({
+  useSharedState: vi.fn()
+}))
+
+vi.mock('@/composables/useCheckTypeSortState', () => ({
+  useCheckTypeSortState: vi.fn()
+}))
+
+vi.mock('@/composables/useFilterState', () => ({
+  useFilterState: vi.fn()
+}))
+
+// Mock the constants
+vi.mock('@/constants/table', () => ({
+  CHECK_TYPE_COLUMNS: [
+    { label: 'Default Branch Violation', key: 'default_branch_violation', tagSeverity: 'danger' },
+    { label: 'Branch Name Violation', key: 'branch_name_violation', tagSeverity: 'warning' },
+    { label: 'Branch Protect Rule Violation', key: 'branch_protect_rule_violation', tagSeverity: 'danger' },
+    { label: 'Exposed Secret Key', key: 'exposed_secret_key', tagSeverity: 'danger' },
+    { label: 'Issue Format Violation', key: 'issue_format_violation', tagSeverity: 'warning' },
+    { label: 'Pull Request Format Violation', key: 'pull_request_format_violation', tagSeverity: 'warning' },
+    { label: 'No Unit Test CI', key: 'no_unit_test_ci', tagSeverity: 'info' },
+    { label: 'Security Risk', key: 'security_risk', tagSeverity: 'danger' },
+    { label: 'Performance Issue', key: 'performance_issue', tagSeverity: 'warning' },
+  ]
+}))
+
+describe('useCheckTypeAlerts', () => {
+  const mockSharedState = {
+    repos: { value: [] as any[] },
+    alertSummaryByCheckType: { value: {} as Record<string, any> },
+    loading: { value: false },
+    error: { value: null },
+    thresholdDate: { value: null },
+    updateThreshold: vi.fn(),
+    fetchRepos: vi.fn(),
+    fetchAlertSummaryByCheckType: vi.fn(),
+    mapFieldToBackend: vi.fn(),
+  }
+
+  const mockSortState = {
+    sortState: { value: { field: null, order: 'asc' } },
+    updateSortState: vi.fn(),
+  }
+
+  const mockFilterState = {
+    filterState: { value: { showOnlyActive: false } },
+    updateShowOnlyActive: vi.fn(),
+    toggleShowOnlyActive: vi.fn(),
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    
+    // Mock the composable functions
+    const { useSharedState } = await import('@/composables/useSharedState')
+    const { useCheckTypeSortState } = await import('@/composables/useCheckTypeSortState')
+    const { useFilterState } = await import('@/composables/useFilterState')
+    
+    ;(useSharedState as any).mockReturnValue(mockSharedState)
+    ;(useCheckTypeSortState as any).mockReturnValue(mockSortState)
+    ;(useFilterState as any).mockReturnValue(mockFilterState)
+  })
+
+  it('should return check type columns', () => {
+    const { columns } = useCheckTypeAlerts()
+    
+    expect(columns).toBeDefined()
+    expect(columns.length).toBeGreaterThan(0)
+    expect(columns[0]).toHaveProperty('label')
+    expect(columns[0]).toHaveProperty('key')
+    expect(columns[0]).toHaveProperty('tagSeverity')
+  })
+
+  it('should map check type data to table rows', () => {
+    const mockRepos = [
+      { owner: 'testowner', name: 'testrepo', lastActivityAt: '2023-01-01' }
+    ]
+    const mockAlertSummary = {
+      'testowner/testrepo': {
+        'default_branch_violation': 3,
+        'branch_protect_rule_violation': 5,
+        'exposed_secret_key': 1
+      }
+    }
+
+    mockSharedState.repos.value = mockRepos
+    mockSharedState.alertSummaryByCheckType.value = mockAlertSummary
+
+    const { tableData } = useCheckTypeAlerts()
+    
+    expect(tableData.value).toHaveLength(1)
+    const row = tableData.value[0]
+    expect(row.default_branch_violation).toBe(3)
+    expect(row.branch_protect_rule_violation).toBe(5)
+    expect(row.exposed_secret_key).toBe(1)
+    expect(row.totalViolations).toBe(9) // 3 + 5 + 1
+  })
+
+  it('should handle empty alert summary data', () => {
+    const mockRepos = [
+      { owner: 'testowner', name: 'testrepo', lastActivityAt: '2023-01-01' }
+    ]
+
+    mockSharedState.repos.value = mockRepos
+    mockSharedState.alertSummaryByCheckType.value = {}
+
+    const { tableData } = useCheckTypeAlerts()
+    
+    expect(tableData.value).toHaveLength(1)
+    const row = tableData.value[0]
+    expect(row.default_branch_violation).toBe(0)
+    expect(row.totalViolations).toBe(0)
+  })
+
+  it('should call fetchAlertSummaryByCheckType when fetching data', async () => {
+    const { fetchData } = useCheckTypeAlerts()
+    
+    await fetchData()
+    
+    expect(mockSharedState.fetchRepos).toHaveBeenCalled()
+    expect(mockSharedState.fetchAlertSummaryByCheckType).toHaveBeenCalled()
+  })
+}) 


### PR DESCRIPTION
## Note  (if necessary)
- Record the NOTES and requirements related to the order of merging PRs or any necessary configurations.

## Description

- Add UI toggle to switch between severity-based and checkType-based alert summary view
 [#37](https://github.com/TeckVeho/health-checker/issues/37)
- Add UI toggle for switching views
- Integrate checkType-based data into frontend
- Refactor alert display component to support both modes
- Remove switch view in detail alert screen

## AI log URL

- useShareState.ts: https://58llm.link/main/restore/9522d4fa-4a97-425b-8ba7-22aeacc272d3
- useTabState.ts: https://58llm.link/main/restore/34d7ea18-cb10-4fb0-88aa-019d667eef50
- useCheckTypeAlert.ts: https://58llm.link/main/restore/f2f3048a-0f67-40bb-8af6-ca703a5df84f
- useChecktypeSortState.ts: https://58llm.link/main/restore/075833ea-4162-4d6a-8a92-b7acb854c273
- useCheckTypeAlert.spec.ts: https://58llm.link/main/restore/d608a1d6-c3bf-476c-8468-8a0460d51a2a

## Evidence
<img width="1882" height="983" alt="image" src="https://github.com/user-attachments/assets/b00a43b2-7567-4741-a236-3ea5749d858a" />
<img width="923" height="446" alt="image" src="https://github.com/user-attachments/assets/10e168ab-0d46-498a-8954-982897656357" />
