### PR TITLE
[Fix UI] Change Alert Table Color Logic: Only 0 is Green, Others are Red

### DIFF
--- a/frontend/src/components/Molecules/RepoTable.vue
+++ b/frontend/src/components/Molecules/RepoTable.vue
@@ -55,7 +55,7 @@
         <template #body="slotProps">
           <HealthTag 
             :value="slotProps.data[column.key]"
-            :severity="slotProps.data[column.key] > 0 ? column.tagSeverity : 'success'" 
+            :severity="slotProps.data[column.key] > 0 ? 'danger' : 'success'" 
           />
         </template>
       </Column>

--- a/frontend/tests/unit/components/Molecules/RepoTable.spec.ts
+++ b/frontend/tests/unit/components/Molecules/RepoTable.spec.ts
@@ -184,14 +184,16 @@ describe('RepoTable Logic', () => {
 
   describe('severity mapping', () => {
     it('should map violation counts to severity levels', () => {
-      const getSeverity = (count: number, tagSeverity: string) => {
-        return count > 0 ? tagSeverity : 'success'
+      const getSeverity = (count: number) => {
+        return count > 0 ? 'danger' : 'success'
       }
 
-      expect(getSeverity(5, 'danger')).toBe('danger')
-      expect(getSeverity(0, 'danger')).toBe('success')
-      expect(getSeverity(1, 'warning')).toBe('warning')
-      expect(getSeverity(0, 'warning')).toBe('success')
+      expect(getSeverity(5)).toBe('danger')
+      expect(getSeverity(0)).toBe('success')
+      expect(getSeverity(1)).toBe('danger')
+      expect(getSeverity(0)).toBe('success')
+      expect(getSeverity(10)).toBe('danger')
+      expect(getSeverity(999)).toBe('danger')
     })
   })
 


### PR DESCRIPTION
## Note  (if necessary)
- Record the NOTES and requirements related to the order of merging PRs or any necessary configurations.

## Description

- [Fix UI] Change Alert Table Color Logic: Only 0 is Green, Others are Red
 [#52](https://github.com/TeckVeho/health-checker/issues/52)
- Update conditional rendering logic for color in severity table
- Test with non-zero middle/low alert cases
- Confirm that 0 is always green and non-zero is always red

## AI log URL

- RepoTable.spec.ts: https://58llm.link/main/restore/bcba09ef-57e4-4090-8a00-2199673ac7b0

## Evidence
<img width="1881" height="854" alt="image" src="https://github.com/user-attachments/assets/9576cca3-a782-43b3-8292-c624208a3c67" />

<img width="911" height="206" alt="image" src="https://github.com/user-attachments/assets/4b40570f-0565-41ed-9171-0cd1be287757" />
<img width="840" height="413" alt="image" src="https://github.com/user-attachments/assets/ac60be2d-d201-4d8c-a7db-72aeb15646f8" />
