### PR TITLE
Convert issue numbers in description to clickable links

### DIFF
--- a/frontend/src/components/Molecules/AlertTable.vue
+++ b/frontend/src/components/Molecules/AlertTable.vue
@@ -44,9 +44,12 @@
       
       <Column field="description" header="Description" class="col-description">
         <template #body="slotProps">
-          <div class="text-sm text-gray-700 truncate" :title="slotProps.data.description" data-label="Description">
-            {{ slotProps.data.description || '-' }}
-          </div>
+          <div 
+            class="text-sm text-gray-700 truncate" 
+            :title="slotProps.data.description" 
+            data-label="Description"
+            v-html="processIssueNumbersLocal(slotProps.data.description || '-')"
+          />
         </template>
       </Column>
       
@@ -96,7 +99,7 @@ import { ref } from 'vue'
 import DataTable from 'primevue/datatable'
 import Column from 'primevue/column'
 import Tag from 'primevue/tag'
-import { getFileUrlLegacy } from '~/utils/github'
+import { getFileUrlLegacy, processIssueNumbers } from '~/utils/github'
 import { useAlerts } from '~/composables/useAlerts'
 
 const props = defineProps({
@@ -171,6 +174,10 @@ const getFileUrl = (filePath, lineNumber, branch) => {
 
 const formatNotes = (notes) => {
   return (notes || '-').replace(/\n/g, '<br>')
+}
+
+const processIssueNumbersLocal = (text) => {
+  return processIssueNumbers(text, props.owner, props.repo)
 }
 </script>
 

--- a/frontend/src/utils/github.ts
+++ b/frontend/src/utils/github.ts
@@ -149,4 +149,25 @@ export function getIssueUrl(owner: string, repo: string, issueNumber: number): s
   }
   
   return `https://github.com/${owner}/${repo}/issues/${issueNumber}`
+}
+
+/**
+ * Processes text and converts issue numbers (e.g., "#123") to clickable links
+ * @param text - The text to process
+ * @param owner - Repository owner
+ * @param repo - Repository name
+ * @returns HTML string with issue numbers converted to links
+ */
+export function processIssueNumbers(text: string, owner: string, repo: string): string {
+  if (!text || !owner || !repo) {
+    return text || ''
+  }
+  
+  // Regular expression to match issue numbers like #123, #456, etc.
+  const issueNumberRegex = /#(\d+)/g
+  
+  return text.replace(issueNumberRegex, (match, issueNumber) => {
+    const issueUrl = getIssueUrl(owner, repo, parseInt(issueNumber))
+    return `<a href="${issueUrl}" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-800 hover:underline transition-colors duration-200">${match}</a>`
+  })
 } 

--- a/frontend/tests/unit/utils/github.spec.ts
+++ b/frontend/tests/unit/utils/github.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { processIssueNumbers, getIssueUrl } from '@/utils/github'
+
+describe('GitHub Utils', () => {
+  describe('processIssueNumbers', () => {
+    it('should convert issue numbers to clickable links', () => {
+      const text = 'Issue #123 lacks clear instructions'
+      const owner = 'test-owner'
+      const repo = 'test-repo'
+      
+      const result = processIssueNumbers(text, owner, repo)
+      
+      expect(result).toContain('<a href="https://github.com/test-owner/test-repo/issues/123"')
+      expect(result).toContain('target="_blank"')
+      expect(result).toContain('rel="noopener noreferrer"')
+      expect(result).toContain('class="text-blue-600 hover:text-blue-800 hover:underline transition-colors duration-200"')
+      expect(result).toContain('>#123</a>')
+    })
+
+    it('should handle multiple issue numbers in the same text', () => {
+      const text = 'Issue #123 and #456 need attention'
+      const owner = 'test-owner'
+      const repo = 'test-repo'
+      
+      const result = processIssueNumbers(text, owner, repo)
+      
+      expect(result).toContain('href="https://github.com/test-owner/test-repo/issues/123"')
+      expect(result).toContain('href="https://github.com/test-owner/test-repo/issues/456"')
+      expect(result).toContain('>#123</a>')
+      expect(result).toContain('>#456</a>')
+    })
+
+    it('should return original text when no issue numbers are found', () => {
+      const text = 'This is a regular description without issue numbers'
+      const owner = 'test-owner'
+      const repo = 'test-repo'
+      
+      const result = processIssueNumbers(text, owner, repo)
+      
+      expect(result).toBe(text)
+    })
+
+    it('should return empty string when text is null or undefined', () => {
+      const owner = 'test-owner'
+      const repo = 'test-repo'
+      
+      expect(processIssueNumbers(null as any, owner, repo)).toBe('')
+      expect(processIssueNumbers(undefined as any, owner, repo)).toBe('')
+    })
+
+    it('should return original text when owner or repo is missing', () => {
+      const text = 'Issue #123 needs attention'
+      
+      expect(processIssueNumbers(text, '', 'test-repo')).toBe(text)
+      expect(processIssueNumbers(text, 'test-owner', '')).toBe(text)
+      expect(processIssueNumbers(text, '', '')).toBe(text)
+    })
+
+    it('should handle issue numbers at the beginning of text', () => {
+      const text = '#123 is the first issue'
+      const owner = 'test-owner'
+      const repo = 'test-repo'
+      
+      const result = processIssueNumbers(text, owner, repo)
+      
+      expect(result).toContain('<a href="https://github.com/test-owner/test-repo/issues/123"')
+      expect(result).toContain('>#123</a>')
+    })
+
+    it('should handle issue numbers at the end of text', () => {
+      const text = 'This is the last issue #789'
+      const owner = 'test-owner'
+      const repo = 'test-repo'
+      
+      const result = processIssueNumbers(text, owner, repo)
+      
+      expect(result).toContain('<a href="https://github.com/test-owner/test-repo/issues/789"')
+      expect(result).toContain('>#789</a>')
+    })
+  })
+
+  describe('getIssueUrl', () => {
+    it('should generate correct issue URL', () => {
+      const result = getIssueUrl('test-owner', 'test-repo', 123)
+      expect(result).toBe('https://github.com/test-owner/test-repo/issues/123')
+    })
+
+    it('should return # for invalid parameters', () => {
+      expect(getIssueUrl('', 'test-repo', 123)).toBe('#')
+      expect(getIssueUrl('test-owner', '', 123)).toBe('#')
+      expect(getIssueUrl('test-owner', 'test-repo', 0)).toBe('#')
+      expect(getIssueUrl('test-owner', 'test-repo', -1)).toBe('#')
+    })
+  })
+}) 


### PR DESCRIPTION
## Note  (if necessary)
- Record the NOTES and requirements related to the order of merging PRs or any necessary configurations.

## Description

- Convert issue numbers in description to clickable links
 [#59](https://github.com/TeckVeho/health-checker/issues/59)
- Current output example: Issue: #123
- Improved output example: Issue: ```<a href="https://github.com/<OWNER>/<REPO>/issues/123">#123</a>```

## AI log URL

- AlertTable.vue: https://58llm.link/main/restore/c1423ab3-703b-414f-9426-20cfca5f8f06
- github.spec.tx: https://58llm.link/main/restore/d8159bd4-0181-4b8e-82bd-40ab6d56d644

## Evidence
<img width="1912" height="819" alt="Screenshot 2025-08-08 153843" src="https://github.com/user-attachments/assets/0afd1110-ef43-43e9-ae24-6ac130d6e82b" />
<img width="875" height="463" alt="image" src="https://github.com/user-attachments/assets/f5242401-1aa8-4d3e-a90a-c7e2888e919b" />
