### PR TITLE
group specific alert types

### DIFF
--- a/frontend/src/composables/useCheckTypeAlerts.ts
+++ b/frontend/src/composables/useCheckTypeAlerts.ts
@@ -2,7 +2,7 @@ import { computed, watch } from 'vue'
 import { useCheckTypeSortState } from './useCheckTypeSortState'
 import { useFilterState } from './useFilterState'
 import { useSharedState } from './useSharedState'
-import { CHECK_TYPE_COLUMNS } from '../constants/table'
+import { CHECK_TYPE_COLUMNS, CHECK_TYPE_MAPPING } from '../constants/table'
 
 export function useCheckTypeAlerts() {
   const { sortState, updateSortState } = useCheckTypeSortState()
@@ -17,6 +17,14 @@ export function useCheckTypeAlerts() {
   // Watch for changes in showOnlyActive to update threshold
   watch(() => filterState.value.showOnlyActive, updateThreshold, { immediate: true })
 
+  // Helper function to calculate category totals
+  const calculateCategoryTotal = (summaryData: Record<string, number>, categoryKey: string): number => {
+    const checkTypes = CHECK_TYPE_MAPPING[categoryKey as keyof typeof CHECK_TYPE_MAPPING] || []
+    return checkTypes.reduce((total, checkType) => {
+      return total + (summaryData[checkType] || 0)
+    }, 0)
+  }
+
   const tableData = computed(() => {
     // Show all repositories, not just those with alerts
     return sharedState.repos.value.map((repo) => {
@@ -26,10 +34,11 @@ export function useCheckTypeAlerts() {
       const row = { ...repo }
       let total = 0
       
-      // Map check type data to columns
+      // Map check type data to grouped columns
       CHECK_TYPE_COLUMNS.forEach((col) => {
-        (row as any)[col.key] = summaryData[col.key] || 0
-        total += (row as any)[col.key] || 0
+        const categoryTotal = calculateCategoryTotal(summaryData, col.key)
+        ;(row as any)[col.key] = categoryTotal
+        total += categoryTotal
       })
       
       // Calculate total
@@ -68,7 +77,7 @@ export function useCheckTypeAlerts() {
         bVal = bVal ? new Date(bVal).getTime() : 0
       }
 
-      // Handle numeric sorting for violation counts
+      // Handle numeric sorting for violation counts (including grouped categories)
       if (['totalViolations', ...CHECK_TYPE_COLUMNS.map(col => col.key)].includes(field)) {
         aVal = Number(aVal) || 0
         bVal = Number(bVal) || 0

--- a/frontend/src/constants/table.ts
+++ b/frontend/src/constants/table.ts
@@ -7,16 +7,53 @@ export const SEVERITY_COLUMNS = [
 
 // Check Type Columns based on checkTypeLabels
 export const CHECK_TYPE_COLUMNS = [
-  { label: 'Default Branch Violation', key: 'default_branch_violation', tagSeverity: 'danger' },
-  { label: 'Branch Name Violation', key: 'branch_name_violation', tagSeverity: 'warning' },
-  { label: 'Branch Protect Rule Violation', key: 'branch_protect_rule_violation', tagSeverity: 'danger' },
-  { label: 'Exposed Secret Key', key: 'exposed_secret_key', tagSeverity: 'danger' },
-  { label: 'Issue Format Violation', key: 'issue_format_violation', tagSeverity: 'warning' },
-  { label: 'Pull Request Format Violation', key: 'pull_request_format_violation', tagSeverity: 'warning' },
-  { label: 'No Unit Test CI', key: 'no_unit_test_ci', tagSeverity: 'info' },
-  { label: 'Security Risk', key: 'security_risk', tagSeverity: 'danger' },
-  { label: 'Performance Issue', key: 'performance_issue', tagSeverity: 'warning' },
+  // Issue category - grouped issue-related alert types
+  { label: 'Issue', key: 'issue', tagSeverity: 'warning' },
+  
+  // Branch category - branch-related violations
+  { label: 'Branch', key: 'branch', tagSeverity: 'danger' },
+  
+  // Security category - security-related issues
+  { label: 'Security', key: 'security', tagSeverity: 'danger' },
+  
+  // Test/Performance category - testing and performance issues
+  { label: 'Test/Performance', key: 'test_performance', tagSeverity: 'info' },
 ] as const
+
+// Individual check types for detailed mapping
+export const CHECK_TYPE_MAPPING = {
+  // Issue category
+  issue: [
+    'issue_unclear_instruction',
+    'issue_template_only', 
+    'issue_missing_end_date',
+    'issue_expired_end_date',
+    'issue_missing_sp',
+    'issue_large_sp',
+    'issue_not_in_project',
+    'issue_format_violation'
+  ],
+  
+  // Branch category
+  branch: [
+    'default_branch_violation',
+    'branch_name_violation',
+    'branch_protect_rule_violation'
+  ],
+  
+  // Security category
+  security: [
+    'exposed_secret_key',
+    'security_risk'
+  ],
+  
+  // Test/Performance category
+  test_performance: [
+    'no_unit_test_ci',
+    'performance_issue',
+    'pull_request_format_violation'
+  ]
+} as const
 
 // Field mapping for backend sorting
 export const FIELD_MAPPING = {

--- a/frontend/src/types/alerts.ts
+++ b/frontend/src/types/alerts.ts
@@ -24,15 +24,29 @@ export interface AlertsResponse {
 
 // Check Type Labels
 export const checkTypeLabels: Record<string, string> = {
+  // Issue-related types
+  issue_unclear_instruction: 'Issue Unclear Instruction',
+  issue_template_only: 'Issue Template Only',
+  issue_missing_end_date: 'Issue Missing End Date',
+  issue_expired_end_date: 'Issue Expired End Date',
+  issue_missing_sp: 'Issue Missing Story Point',
+  issue_large_sp: 'Issue Large Story Point',
+  issue_not_in_project: 'Issue Not In Project',
+  issue_format_violation: 'Issue Format Violation',
+  
+  // Branch-related types
   default_branch_violation: 'Default Branch Violation',
   branch_name_violation: 'Branch Name Violation',
   branch_protect_rule_violation: 'Branch Protect Rule Violation',
+  
+  // Security-related types
   exposed_secret_key: 'Exposed Secret Key',
-  issue_format_violation: 'Issue Format Violation',
-  pull_request_format_violation: 'Pull Request Format Violation',
-  no_unit_test_ci: 'No Unit Test CI',
   security_risk: 'Security Risk',
+  
+  // Test/Performance-related types
+  no_unit_test_ci: 'No Unit Test CI',
   performance_issue: 'Performance Issue',
+  pull_request_format_violation: 'Pull Request Format Violation',
 }
 
 // Component Props Types

--- a/frontend/tests/unit/composables/useCheckTypeAlerts.spec.ts
+++ b/frontend/tests/unit/composables/useCheckTypeAlerts.spec.ts
@@ -17,16 +17,37 @@ vi.mock('@/composables/useFilterState', () => ({
 // Mock the constants
 vi.mock('@/constants/table', () => ({
   CHECK_TYPE_COLUMNS: [
-    { label: 'Default Branch Violation', key: 'default_branch_violation', tagSeverity: 'danger' },
-    { label: 'Branch Name Violation', key: 'branch_name_violation', tagSeverity: 'warning' },
-    { label: 'Branch Protect Rule Violation', key: 'branch_protect_rule_violation', tagSeverity: 'danger' },
-    { label: 'Exposed Secret Key', key: 'exposed_secret_key', tagSeverity: 'danger' },
-    { label: 'Issue Format Violation', key: 'issue_format_violation', tagSeverity: 'warning' },
-    { label: 'Pull Request Format Violation', key: 'pull_request_format_violation', tagSeverity: 'warning' },
-    { label: 'No Unit Test CI', key: 'no_unit_test_ci', tagSeverity: 'info' },
-    { label: 'Security Risk', key: 'security_risk', tagSeverity: 'danger' },
-    { label: 'Performance Issue', key: 'performance_issue', tagSeverity: 'warning' },
-  ]
+    { label: 'Issue', key: 'issue', tagSeverity: 'warning' },
+    { label: 'Branch', key: 'branch', tagSeverity: 'danger' },
+    { label: 'Security', key: 'security', tagSeverity: 'danger' },
+    { label: 'Test/Performance', key: 'test_performance', tagSeverity: 'info' },
+  ],
+  CHECK_TYPE_MAPPING: {
+    issue: [
+      'issue_unclear_instruction',
+      'issue_template_only', 
+      'issue_missing_end_date',
+      'issue_expired_end_date',
+      'issue_missing_sp',
+      'issue_large_sp',
+      'issue_not_in_project',
+      'issue_format_violation'
+    ],
+    branch: [
+      'default_branch_violation',
+      'branch_name_violation',
+      'branch_protect_rule_violation'
+    ],
+    security: [
+      'exposed_secret_key',
+      'security_risk'
+    ],
+    test_performance: [
+      'no_unit_test_ci',
+      'performance_issue',
+      'pull_request_format_violation'
+    ]
+  }
 }))
 
 describe('useCheckTypeAlerts', () => {
@@ -84,7 +105,9 @@ describe('useCheckTypeAlerts', () => {
       'testowner/testrepo': {
         'default_branch_violation': 3,
         'branch_protect_rule_violation': 5,
-        'exposed_secret_key': 1
+        'exposed_secret_key': 1,
+        'issue_missing_sp': 2,
+        'no_unit_test_ci': 1
       }
     }
 
@@ -95,10 +118,13 @@ describe('useCheckTypeAlerts', () => {
     
     expect(tableData.value).toHaveLength(1)
     const row = tableData.value[0]
-    expect(row.default_branch_violation).toBe(3)
-    expect(row.branch_protect_rule_violation).toBe(5)
-    expect(row.exposed_secret_key).toBe(1)
-    expect(row.totalViolations).toBe(9) // 3 + 5 + 1
+    
+    // Check grouped categories
+    expect(row.issue).toBe(2) // issue_missing_sp
+    expect(row.branch).toBe(8) // default_branch_violation + branch_protect_rule_violation
+    expect(row.security).toBe(1) // exposed_secret_key
+    expect(row.test_performance).toBe(1) // no_unit_test_ci
+    expect(row.totalViolations).toBe(12) // 2 + 8 + 1 + 1
   })
 
   it('should handle empty alert summary data', () => {
@@ -113,8 +139,44 @@ describe('useCheckTypeAlerts', () => {
     
     expect(tableData.value).toHaveLength(1)
     const row = tableData.value[0]
-    expect(row.default_branch_violation).toBe(0)
+    expect(row.issue).toBe(0)
+    expect(row.branch).toBe(0)
+    expect(row.security).toBe(0)
+    expect(row.test_performance).toBe(0)
     expect(row.totalViolations).toBe(0)
+  })
+
+  it('should handle all issue types in the Issue category', () => {
+    const mockRepos = [
+      { owner: 'testowner', name: 'testrepo', lastActivityAt: '2023-01-01' }
+    ]
+    const mockAlertSummary = {
+      'testowner/testrepo': {
+        'issue_unclear_instruction': 1,
+        'issue_template_only': 2,
+        'issue_missing_end_date': 1,
+        'issue_expired_end_date': 1,
+        'issue_missing_sp': 3,
+        'issue_large_sp': 1,
+        'issue_not_in_project': 2,
+        'issue_format_violation': 1
+      }
+    }
+
+    mockSharedState.repos.value = mockRepos
+    mockSharedState.alertSummaryByCheckType.value = mockAlertSummary
+
+    const { tableData } = useCheckTypeAlerts()
+    
+    expect(tableData.value).toHaveLength(1)
+    const row = tableData.value[0]
+    
+    // All issue types should be grouped into the 'issue' category
+    expect(row.issue).toBe(12) // 1+2+1+1+3+1+2+1 = 12
+    expect(row.branch).toBe(0)
+    expect(row.security).toBe(0)
+    expect(row.test_performance).toBe(0)
+    expect(row.totalViolations).toBe(12)
   })
 
   it('should call fetchAlertSummaryByCheckType when fetching data', async () => {


### PR DESCRIPTION
## Note  (if necessary)
- Record the NOTES and requirements related to the order of merging PRs or any necessary configurations.

## Description

- Group specific alert types
 [#60](https://github.com/TeckVeho/health-checker/issues/60)
- Implement grouping logic for the "Issue" column
- Implement the new category grouping
- Update the health-checker table rendering

## AI log URL

- useCheckTypeAlerts.spec.ts: https://58llm.link/main/restore/c0090fe8-f708-49ee-b703-7f32b0f85859
- useCheckTypeAlerts.ts: https://58llm.link/main/restore/c769b923-e61d-427c-955d-7f0fc460ad01

## Evidence
<img width="1877" height="894" alt="image" src="https://github.com/user-attachments/assets/f26e5d13-e562-430f-b64a-b5f8cb6b4ecf" />
<img width="835" height="468" alt="image" src="https://github.com/user-attachments/assets/fffafea2-2c80-4a22-8010-5592e3de1022" />
