### PR TITLE
Issue Alert: Exclude Pull Requests and Track Issues Only

### DIFF
--- a/backend/src/domain/alert/util/checkIssues.ts
+++ b/backend/src/domain/alert/util/checkIssues.ts
@@ -42,16 +42,24 @@ export async function checkIssues(owner: string, repo: string): Promise<CheckIss
   const codeSnippet = '';
   const branch = '';
 
+  // Note: This function only processes actual GitHub Issues, not Pull Requests.
+  // GitHub's issues.listForRepo API returns both issues and PRs, so we filter out PRs
+  // to ensure we only generate alerts for genuine issues.
+
   try {
     // Get all open issues with pagination
-    const issues = await octokit.paginate(octokit.issues.listForRepo, {
+    const allItems = await octokit.paginate(octokit.issues.listForRepo, {
       owner,
       repo,
       state: 'open',
       per_page: 100,
     });
 
-    console.log(`📋 Found ${issues.length} open issues for ${owner}/${repo}`);
+    // Filter out pull requests - only keep actual issues
+    const issues = allItems.filter(item => !item.pull_request);
+    
+    console.log(`📋 Found ${allItems.length} open items (issues + PRs) for ${owner}/${repo}`);
+    console.log(`📋 Filtered to ${issues.length} actual issues (excluded ${allItems.length - issues.length} PRs)`);
 
     // Cache project data to avoid multiple API calls
     // const projectCache = new Map<number, boolean>();
@@ -68,6 +76,13 @@ export async function checkIssues(owner: string, repo: string): Promise<CheckIss
     
     for (let i = 0; i < issues.length; i++) {
       const issue = issues[i];
+      
+      // Double-check: ensure this is actually an issue, not a PR
+      if (issue.pull_request) {
+        console.log(`⚠️ Skipping PR #${issue.number} - this should not happen after filtering`);
+        continue;
+      }
+      
       console.log(`🔍 Processing issue #${issue.number} (${i + 1}/${issues.length})`);
       
       // Get field values from projects (priority) and body (fallback)

--- a/backend/tests/unit/domain/alert/checkIssues.test.ts
+++ b/backend/tests/unit/domain/alert/checkIssues.test.ts
@@ -221,6 +221,57 @@ describe('checkIssues', () => {
       expect(alert?.title).toBe('issue:5');
       expect(alert?.severity).toBe('middle');
     });
+
+    it('should filter out pull requests and only process actual issues', async () => {
+      const mockItems = [
+        {
+          number: 1,
+          title: 'Test Issue',
+          body: 'This is an actual issue',
+          html_url: 'https://github.com/test-owner/test-repo/issues/1',
+          pull_request: undefined, // No pull_request property = actual issue
+        },
+        {
+          number: 2,
+          title: 'Test Pull Request',
+          body: 'This is a pull request',
+          html_url: 'https://github.com/test-owner/test-repo/pull/2',
+          pull_request: {}, // Has pull_request property = PR
+        },
+        {
+          number: 3,
+          title: 'Another Issue',
+          body: 'This is another issue',
+          html_url: 'https://github.com/test-owner/test-repo/issues/3',
+          pull_request: undefined, // No pull_request property = actual issue
+        },
+      ];
+
+      mockOctokit.paginate.mockResolvedValue(mockItems);
+      mockOctokit.graphql.mockResolvedValue({
+        repository: {
+          projectsV2: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [],
+          },
+        },
+      });
+
+      const result = await checkIssues(owner, repo);
+
+      // Should only process 2 actual issues (filtered out 1 PR)
+      // Each issue should generate 5 alerts (basic + template_only + unclear_instruction)
+      expect(result.alerts).toHaveLength(10);
+      
+      // Verify that we have alerts for both issues but not for the PR
+      const issue1Alerts = result.alerts.filter(a => a.title === 'issue:1');
+      const issue3Alerts = result.alerts.filter(a => a.title === 'issue:3');
+      const pr2Alerts = result.alerts.filter(a => a.title === 'issue:2');
+      
+      expect(issue1Alerts.length).toBeGreaterThan(0);
+      expect(issue3Alerts.length).toBeGreaterThan(0);
+      expect(pr2Alerts.length).toBe(0); // PR should not have any alerts
+    });
   });
 
   describe('GitHub Projects V2 field values', () => {


### PR DESCRIPTION
## Note  (if necessary)
- Record the NOTES and requirements related to the order of merging PRs or any necessary configurations.

## Description

- Issue Alert: Exclude Pull Requests and Track Issues Only
- [#64](https://github.com/TeckVeho/health-checker/issues/64)

- Only issues are considered by the Issue Alert pipeline.
- PRs are excluded at all stages (ingestion, processing, persistence, and UI).
- Historical data: existing PR-derived alerts are either cleaned up or clearly labeled as excluded (see Checklist).

## AI log URL
- checkIssue.test.ts: https://58llm.link/main/restore/cb79b767-3ea4-43f1-820f-0fcdd493a7a8
- checkIssue.ts: https://58llm.link/main/restore/5359efa2-eec5-44fd-87df-b8310643e02e

## Evidence
<img width="953" height="513" alt="image" src="https://github.com/user-attachments/assets/4209cb0e-bcbf-4ead-8ce6-22a6d03b8101" />
<img width="800" height="570" alt="Screenshot 2025-08-19 170805" src="https://github.com/user-attachments/assets/613508d7-42aa-4fe0-a4fd-e3a36e9f2af4" />
