### PR TITLE
Fix LLM temperature parameter compatibility with gpt-5-mini model

### DIFF
--- a/backend/src/domain/alert/util/checkIssues/llm.ts
+++ b/backend/src/domain/alert/util/checkIssues/llm.ts
@@ -46,6 +46,7 @@ Respond ONLY in this JSON format:
     const result = await generateText({
       model: openai(OPENAI_CONFIG.MODEL),
       prompt,
+      temperature: 1,
     });
 
     const content = result.text?.trim();
@@ -117,6 +118,7 @@ Respond ONLY in this JSON format:
     const result = await generateText({
       model: openai(OPENAI_CONFIG.MODEL),
       prompt,
+      temperature: 1,
     });
 
     const content = result.text?.trim();

--- a/backend/src/domain/githubAction/util/PRCheck.ts
+++ b/backend/src/domain/githubAction/util/PRCheck.ts
@@ -84,6 +84,7 @@ export class PRCheck {
       const result = await generateText({
         model: openai(OPENAI_CONFIG.MODEL),
         prompt,
+        temperature: 1,
       });
 
       const content = result.text?.trim();


### PR DESCRIPTION
## Summary
- Fix OpenAI API error caused by temperature=0 parameter with gpt-5-mini model
- Add explicit temperature: 1 to all generateText calls to override AI SDK default
- Resolves issue #98

## Changes
- **backend/src/domain/alert/util/checkIssues/llm.ts**: Add temperature: 1 to template and unclear detection calls
- **backend/src/domain/githubAction/util/PRCheck.ts**: Add temperature: 1 to PR content analysis call

## Root Cause
The AI SDK package defaults to `temperature: 0` when not specified, but the gpt-5-mini model only supports `temperature: 1` (default value). This caused APICallError with message "Unsupported value: 'temperature' does not support 0 with this model."

## Test Plan
- [x] Unit tests pass (existing LLM mocks work correctly)
- [x] Linting passes with no errors on modified files
- [x] All generateText calls now explicitly set temperature: 1

## Impact
- Fixes LLM template detection errors
- Fixes LLM unclear instructions detection errors  
- Fixes PR content analysis errors
- No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)