### PR TITLE
feat: Add no-repocheck topic skip functionality (#102)

### DIFF
--- a/backend/src/domain/alert/alertService.ts
+++ b/backend/src/domain/alert/alertService.ts
@@ -10,6 +10,11 @@ import { checkIssues, type IssueAlertCandidate } from './util/checkIssues';
 import { checkActions } from './util/checkActions';
 import { QueryTypes, Op } from 'sequelize';
 import { subDays, format } from 'date-fns';
+import { Octokit } from '@octokit/rest';
+
+// GitHub API client
+const githubToken = process.env.GITHUB_API_KEY;
+const octokit = new Octokit({ auth: githubToken });
 
 // Define Repo model directly from schema
 class Repo extends Model {}
@@ -26,6 +31,21 @@ Alert.init(alertAttributes, {
 });
 
 class AlertService {
+  /**
+   * Check if a repository has the 'no-repocheck' topic
+   */
+  private static async hasNoRepocheckTopic(owner: string, repo: string): Promise<boolean> {
+    try {
+      const response = await octokit.rest.repos.getAllTopics({
+        owner,
+        repo,
+      });
+      return response.data.names.includes('no-repocheck');
+    } catch (error) {
+      console.warn(`⚠️ Failed to fetch topics for ${owner}/${repo}:`, (error as Error).message);
+      return false; // If we can't fetch topics, proceed with checks
+    }
+  }
   static async getAlertsByRepo(owner: string, repo: string) {
     const alerts = await Alert.findAll({
       where: {
@@ -454,13 +474,29 @@ class AlertService {
     const results: Record<string, unknown>[] = [];
 
     for (const repo of repos) {
+      const repoName = (repo as any).name;
+      const repoOwner = (repo as any).owner;
+      
       try {
-        const result = await this.runAlert({ owner: (repo as any).owner, repo: (repo as any).name, checks });
-        results.push({ repo: (repo as any).name, ...result });
+        // Check if repository has 'no-repocheck' topic
+        const hasSkipTopic = await this.hasNoRepocheckTopic(repoOwner, repoName);
+        
+        if (hasSkipTopic) {
+          console.log(`⏭️ Skipping ${repoOwner}/${repoName}: 'no-repocheck' topic found`);
+          results.push({ 
+            repo: repoName, 
+            status: 'skipped',
+            reason: 'no-repocheck topic present'
+          });
+          continue;
+        }
+
+        const result = await this.runAlert({ owner: repoOwner, repo: repoName, checks });
+        results.push({ repo: repoName, ...result });
       } catch (err) {
-        console.error(`❌ Failed to process ${(repo as any).name}`, err);
+        console.error(`❌ Failed to process ${repoName}`, err);
         results.push({
-          repo: (repo as any).name,
+          repo: repoName,
           status: 'error',
           error: (err as Error).message,
         });


### PR DESCRIPTION
## Summary
Implements functionality to skip repository checks when the `no-repocheck` topic is present on GitHub repositories.

## Problem
Some repositories may not require health checks for various reasons (archived, experimental, external dependencies, etc.). Previously, there was no easy way to exclude repositories from health checks without modifying the codebase.

## Solution
- Added `hasNoRepocheckTopic()` method to check GitHub repository topics via API
- Modified `checkStoredRepos()` to skip repositories with `no-repocheck` topic
- Added proper logging when repositories are skipped
- Return skip status and reason in results

## How it Works
1. Before running health checks on each repository, the system fetches the repository's topics from GitHub API
2. If the `no-repocheck` topic is found, the repository is skipped
3. Skipped repositories are logged and marked in the results with skip reason
4. Other repositories continue to be checked normally

## Benefits
- Provides a flexible way to exclude repositories from checks
- No code changes required to exclude/include repositories
- Can be managed directly from GitHub repository settings
- Graceful error handling if topics cannot be fetched

## Usage
To skip health checks for a repository:
1. Go to the repository settings on GitHub
2. Add `no-repocheck` to the Topics section
3. The repository will be automatically skipped in the next health check run

## Example Output
```
⏭️ Skipping TeckVeho/example-repo: 'no-repocheck' topic found
```

Closes #102

🤖 Generated with [Claude Code](https://claude.ai/code)