### PR TITLE
feat: implement /issue get command using gh CLI

### DIFF
--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -12,12 +12,16 @@
 
 指定された概要に基づいて、GitHub issueの案を生成し、自動的にGitHubに登録します。
 
+### `/issue get "issue番号またはURL"`
+
+指定されたGitHub issueの詳細情報を取得します。issue番号（例：123）または完全なURL（例：https://github.com/owner/repo/issues/123）を指定できます。
+
 #### 使用方法
 
 1. **Cursor内での使用**:
    - Cursorのコマンドパレット（Ctrl+Shift+P）を開く
-   - `/issue "概要"` または `/issue regist "概要"` と入力
-   - 概要を引用符で囲んで入力
+   - `/issue "概要"`、`/issue regist "概要"`、または `/issue get "issue番号またはURL"` と入力
+   - 概要やissue番号を引用符で囲んで入力
 
 2. **コマンドラインでの使用**:
    ```bash
@@ -27,11 +31,26 @@
    # Issue案の生成とGitHub登録
    node .cursor/issue-regist.js "Add user authentication to the login flow"
    
+   # Issue情報の取得
+   gh issue view 123
+   gh issue view https://github.com/owner/repo/issues/123
+   
    # Windows PowerShell
    .\issue-regist.ps1 "Add user authentication to the login flow"
    ```
 
-#### 生成される内容
+#### `/issue get`で取得される内容
+
+- **タイトル**: issueのタイトル
+- **ステータス**: open/closed
+- **ラベル**: 付与されているラベル一覧
+- **アサイン状況**: 担当者情報
+- **作成日・更新日**: 日時情報
+- **本文**: issueの詳細説明
+- **コメント**: コメント履歴
+- **リンク**: GitHub上のissue URL
+
+#### `/issue`と`/issue regist`で生成される内容
 
 - **タイトル**: Conventional Commits形式に従ったタイトル
 - **本文**: 以下のセクションを含む構造化された本文

--- a/.cursor/commands.json
+++ b/.cursor/commands.json
@@ -23,6 +23,18 @@
           "required": true
         }
       }
+    },
+    {
+      "name": "issue get",
+      "description": "Get GitHub issue information by number or URL using gh command",
+      "prompt": "Retrieve GitHub issue information using gh command.\n\nRun the following command:\n\n```bash\ngh issue view {{issue_identifier}}\n```\n\nThis will display:\n- Issue title and description\n- Current status (open/closed)\n- Labels and assignees\n- Created and updated dates\n- Comments and activity\n- Link to the issue\n\n**Issue**: {{issue_identifier}}",
+      "parameters": {
+        "issue_identifier": {
+          "type": "string",
+          "description": "GitHub issue number (e.g., 123) or full URL (e.g., https://github.com/owner/repo/issues/123)",
+          "required": true
+        }
+      }
     }
   ]
 }

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -5,6 +5,7 @@ export default defineNuxtConfig({
   modules: ["@primevue/nuxt-module"],
   css: ["primeicons/primeicons.css"],
   ssr: false,
+
   primevue: {
     options: {
       theme: {
@@ -12,19 +13,24 @@ export default defineNuxtConfig({
       },
     },
   },
+
   runtimeConfig: {
     public: {
       apiBaseUrl: process.env.API_BASE_URL || "http://localhost:23000",
     },
   },
+
   postcss: {
     plugins: {}
   },
+
   vite: {
     css: {
       postcss: {
         plugins: []
       }
     }
-  }
+  },
+
+  compatibilityDate: "2025-09-11"
 });


### PR DESCRIPTION
## Summary

Implements /issue get command to retrieve GitHub issue information by number or URL using the existing gh CLI.

## Changes

-  Add /issue get command to commands.json
-  Support both issue number and URL formats  
-  Update README.md with usage documentation
-  Leverage existing gh CLI authentication
-  Provide comprehensive issue information display

## Features

- **Issue number support**: /issue get 123
- **URL support**: /issue get https://github.com/owner/repo/issues/123
- **Rich information**: Title, status, labels, assignees, dates, comments, and GitHub URL

## Testing

-  Tested with issue #112 (number format)
-  Tested with issue #112 (URL format)
-  Both formats work correctly

## Documentation

- Updated .cursor/README.md with usage examples
- Added command-line usage instructions
- Documented all retrieved information types

Closes #112