### PR TITLE
fix: Remove codeSnippet from unique index

### DIFF
--- a/backend/src/domain/alert/alertSchema.ts
+++ b/backend/src/domain/alert/alertSchema.ts
@@ -165,6 +165,8 @@ export const alertModelOptions = {
     {
       name: 'unique_health_issue',
       unique: true,
+      // Note: code_snippet is intentionally excluded from unique index
+      // to allow multiple alerts with same details but different code snippets
       fields: [
         { name: 'owner', length: 100 },
         { name: 'repo', length: 100 },


### PR DESCRIPTION
## 概要

Alertテーブルのunique indexからcodeSnippetを除外する修正です。

## 修正内容

- unique_health_issue indexからcode_snippetフィールドを削除
- 同じ詳細で異なるコードスニペットを持つ複数のアラートを許可
- アラート検出と管理の柔軟性を向上
- コメントを追加して除外理由を明記

## 技術的詳細

### 変更前
`	ypescript
fields: [
  { name: 'owner', length: 100 },
  { name: 'repo', length: 100 },
  { name: 'check_type', length: 50 },
  { name: 'title', length: 50 },
  { name: 'file_path', length: 255 },
  { name: 'line_number' },
  { name: 'code_snippet', length: 255 }, //  削除
  { name: 'branch', length: 50 },
]
`

### 変更後
`	ypescript
// Note: code_snippet is intentionally excluded from unique index
// to allow multiple alerts with same details but different code snippets
fields: [
  { name: 'owner', length: 100 },
  { name: 'repo', length: 100 },
  { name: 'check_type', length: 50 },
  { name: 'title', length: 50 },
  { name: 'file_path', length: 255 },
  { name: 'line_number' },
  { name: 'branch', length: 50 },
]
`

## 期待される効果

- 同一ファイルの異なる行で同じタイプの問題が発生した場合のアラート登録が可能
- コードスニペットが異なる場合でも適切にアラートが管理される
- より柔軟なアラート検出と管理が可能になる

## テスト

- データベースマイグレーションのテストが必要
- 既存のアラートデータとの互換性確認が必要