### PR TITLE
fix: 本番環境でGITHUB_LOCAL_WORKSPACE環境変数が読み込まれない問題を修正

### DIFF
--- a/backend/ecosystem.config.cjs
+++ b/backend/ecosystem.config.cjs
@@ -1,5 +1,17 @@
 const dotenv = require('dotenv');
-dotenv.config();
+const path = require('path');
+
+// 本番環境での.envファイルのパスを明示的に指定
+const envPath = path.resolve(__dirname, '.env');
+console.log(`[PM2] Loading environment from: ${envPath}`);
+
+const result = dotenv.config({ path: envPath });
+if (result.error) {
+  console.error(`[PM2] Error loading .env file:`, result.error);
+} else {
+  console.log(`[PM2] Environment loaded successfully from: ${envPath}`);
+  console.log(`[PM2] GITHUB_LOCAL_WORKSPACE: ${process.env.GITHUB_LOCAL_WORKSPACE || 'NOT SET'}`);
+}
 
 module.exports = {
     apps: [

--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -1,9 +1,7 @@
 import { Sequelize } from 'sequelize';
 import path from 'path';
-import dotenv from 'dotenv';
 
-const envFile = process.env.NODE_ENV === 'test' ? '../../.env.test' : '../../.env';
-dotenv.config({ path: path.resolve(__dirname, envFile) });
+// 環境変数はEnvironmentConfigで初期化済み
 
 const DB_NAME = process.env.DB_NAME as string;
 const DB_USER = process.env.DB_USER as string;

--- a/backend/src/config/environment.ts
+++ b/backend/src/config/environment.ts
@@ -1,0 +1,113 @@
+import dotenv from 'dotenv';
+import path from 'path';
+import fs from 'fs';
+
+/**
+ * 環境変数の初期化と検証
+ */
+export class EnvironmentConfig {
+  private static initialized = false;
+
+  /**
+   * 環境変数を初期化
+   */
+  static initialize(): void {
+    if (this.initialized) {
+      return;
+    }
+
+    console.log('[EnvironmentConfig] Initializing environment variables...');
+
+    // アプリケーションのルートディレクトリを取得
+    const appRoot = process.cwd();
+    console.log(`[EnvironmentConfig] Application root: ${appRoot}`);
+
+    // .envファイルのパスを決定
+    const envFile = process.env.NODE_ENV === 'test' ? '.env.test' : '.env';
+    const envPath = path.resolve(appRoot, envFile);
+
+    console.log(`[EnvironmentConfig] Looking for .env file at: ${envPath}`);
+
+    // .envファイルの存在確認
+    try {
+      fs.accessSync(envPath, fs.constants.F_OK);
+      console.log(`[EnvironmentConfig] .env file found at: ${envPath}`);
+    } catch (error) {
+      console.error(`[EnvironmentConfig] .env file not found at: ${envPath}`);
+      console.error(`[EnvironmentConfig] Error:`, error);
+      return;
+    }
+
+    // dotenv.config()を実行
+    const result = dotenv.config({ path: envPath });
+    
+    if (result.error) {
+      console.error(`[EnvironmentConfig] Error loading .env file:`, result.error);
+    } else {
+      console.log(`[EnvironmentConfig] Environment loaded successfully from: ${envPath}`);
+    }
+
+    // 重要な環境変数の確認
+    this.validateCriticalVariables();
+
+    this.initialized = true;
+  }
+
+  /**
+   * 重要な環境変数の検証
+   */
+  private static validateCriticalVariables(): void {
+    const criticalVars = [
+      'GITHUB_API_KEY',
+      'GITHUB_LOCAL_WORKSPACE',
+      'DB_HOST',
+      'DB_USER',
+      'DB_NAME',
+      'DB_PASSWORD'
+    ];
+
+    console.log('[EnvironmentConfig] Validating critical environment variables:');
+    
+    for (const varName of criticalVars) {
+      const value = process.env[varName];
+      if (value) {
+        // 機密情報は一部のみ表示
+        const displayValue = varName.includes('PASSWORD') || varName.includes('KEY') 
+          ? `${value.substring(0, 8)}...` 
+          : value;
+        console.log(`[EnvironmentConfig] ✅ ${varName}: ${displayValue}`);
+      } else {
+        console.error(`[EnvironmentConfig] ❌ ${varName}: NOT SET`);
+      }
+    }
+
+    // GITHUB_LOCAL_WORKSPACEの特別な検証
+    const workspace = process.env.GITHUB_LOCAL_WORKSPACE;
+    if (workspace) {
+      try {
+        fs.accessSync(workspace, fs.constants.F_OK | fs.constants.W_OK);
+        console.log(`[EnvironmentConfig] ✅ GITHUB_LOCAL_WORKSPACE directory accessible: ${workspace}`);
+      } catch (error) {
+        console.error(`[EnvironmentConfig] ❌ GITHUB_LOCAL_WORKSPACE directory not accessible: ${workspace}`);
+        console.error(`[EnvironmentConfig] Error:`, error);
+      }
+    }
+  }
+
+  /**
+   * 環境変数の状態を取得
+   */
+  static getStatus(): {
+    initialized: boolean;
+    githubWorkspace: string | undefined;
+    githubApiKey: string | undefined;
+    dbHost: string | undefined;
+  } {
+    return {
+      initialized: this.initialized,
+      githubWorkspace: process.env.GITHUB_LOCAL_WORKSPACE,
+      githubApiKey: process.env.GITHUB_API_KEY,
+      dbHost: process.env.DB_HOST
+    };
+  }
+}

--- a/backend/src/config/openai.ts
+++ b/backend/src/config/openai.ts
@@ -1,8 +1,4 @@
-import dotenv from 'dotenv';
-import path from 'path';
-
-const envFile = process.env.NODE_ENV === 'test' ? '../../.env.test' : '../../.env';
-dotenv.config({ path: path.resolve(__dirname, envFile) });
+// 環境変数はEnvironmentConfigで初期化済み
 
 export const OPENAI_CONFIG = {
   API_KEY: process.env.OPENAI_API_KEY as string,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,7 +1,20 @@
 import app from './app';
+import { EnvironmentConfig } from './config/environment';
+
+// 環境変数の初期化
+EnvironmentConfig.initialize();
 
 const PORT = process.env.PORT || 3000;
 
 app.listen(PORT, () => {
   console.log(`Server is running on port ${PORT}`);
+  
+  // 環境変数の状態をログ出力
+  const envStatus = EnvironmentConfig.getStatus();
+  console.log('[Server] Environment status:', {
+    initialized: envStatus.initialized,
+    githubWorkspace: envStatus.githubWorkspace ? 'SET' : 'NOT SET',
+    githubApiKey: envStatus.githubApiKey ? 'SET' : 'NOT SET',
+    dbHost: envStatus.dbHost ? 'SET' : 'NOT SET'
+  });
 });

--- a/backend/src/middlewares/environmentCheck.ts
+++ b/backend/src/middlewares/environmentCheck.ts
@@ -16,9 +16,12 @@ export const environmentCheck = async (req: Request, res: Response, next: NextFu
     
     const validation = await EnvironmentValidator.validateEnvironment();
     
+    // 詳細な検証結果をログ出力
+    EnvironmentValidator.logValidationResult(validation);
+    
     // 環境変数が無効な場合の処理
     if (!validation.isValid) {
-      console.error(`[EnvironmentCheck] Environment validation failed:`, validation);
+      console.error(`[EnvironmentCheck] Environment validation failed`);
       
       // 警告のみで続行（フォールバック処理に委ねる）
       if (validation.warnings.length > 0) {
@@ -35,11 +38,12 @@ export const environmentCheck = async (req: Request, res: Response, next: NextFu
           message: 'Environment configuration error',
           error: {
             code: 'ENVIRONMENT_ERROR',
-            message: `Missing required environment variables: ${missingVars}`,
+            message: `Environment validation failed:\nMissing required variables: ${missingVars}\n\nPlease check your environment configuration and try again.`,
             details: {
               missingVariables: validation.missingVars,
               warnings: validation.warnings,
-              fallbackPaths: validation.fallbackPaths
+              fallbackPaths: validation.fallbackPaths,
+              environmentDetails: validation.details
             }
           }
         });

--- a/backend/src/utils/environmentUtils.ts
+++ b/backend/src/utils/environmentUtils.ts
@@ -257,5 +257,16 @@ export class EnvironmentValidator {
       console.log('   Fallback Paths:');
       result.fallbackPaths.forEach(path => console.log(`     - ${path}`));
     }
+
+    // 詳細な環境変数情報を出力
+    console.log('   Environment Variables Details:');
+    Object.entries(result.details).forEach(([varName, details]) => {
+      const status = details.exists ? (details.isValid ? '✅' : '⚠️') : '❌';
+      const value = details.value || 'NOT SET';
+      console.log(`     ${status} ${varName}: ${value}`);
+      if (details.error) {
+        console.log(`        Error: ${details.error}`);
+      }
+    });
   }
 }


### PR DESCRIPTION
## 概要
本番環境でGITHUB_LOCAL_WORKSPACE環境変数が読み込まれない問題を修正しました。

## 問題
PR #143でPM2設定にdotenv.config()を追加したが、本番環境でGITHUB_LOCAL_WORKSPACE環境変数が依然として読み込まれていませんでした。

## 解決策
1. **PM2設定の改善**: dotenv.config()のパス指定を明示的に設定し、環境変数読み込みのログを追加
2. **新しい環境設定クラス**: EnvironmentConfigクラスによる環境変数初期化の一元管理
3. **アプリケーション起動の強化**: 起動時の環境変数検証とログ出力の改善
4. **重複コードの削除**: 既存設定ファイルでの重複したdotenv.config()呼び出しを削除
5. **診断機能の強化**: より詳細な診断情報とエラーハンドリングの改善

## 主な変更内容
- \ackend/ecosystem.config.cjs\: PM2起動時の環境変数読み込みログ追加
- \ackend/src/config/environment.ts\: 新しい環境変数初期化クラス
- \ackend/src/index.ts\: アプリケーション起動時の環境変数初期化
- \ackend/src/config/database.ts, openai.ts\: 重複したdotenv.config()削除
- \ackend/src/utils/environmentUtils.ts\: 詳細な診断情報の追加
- \ackend/src/middlewares/environmentCheck.ts\: 改善されたエラーメッセージ

## テスト結果
-  環境変数読み込みが正常に動作
-  GITHUB_LOCAL_WORKSPACEが正しく読み込まれる
-  アプリケーション起動が成功
-  TypeScriptコンパイルエラーなし

## 本番環境での対応
1. PM2プロセスの再起動: \pm2 restart backend-prod\
2. ログの確認: \pm2 logs backend-prod\
3. ReCheck機能のテスト

Closes #144