### PR TITLE
feat: Add missing frontend files for Issue #174 PR category implementation

### DIFF
--- a/docs/issues/174/dev.md
+++ b/docs/issues/174/dev.md
@@ -1,0 +1,111 @@
+# Issue #174: Show PR alert check type-based-view / Author based-view - 開発ログ
+
+## 目的
+check type-based-view / Author based-view で、PR bodyチェックのアラートのカウントが表示されていない問題を解決し、適切に表示されるようにする。
+
+## 開発開始日
+2025-01-27
+
+## フェーズ1: 要件分析と現状確認
+
+### 1.1. バックエンドAPIの確認
+- **エンドポイント**: `/api/alerts/by-author` および `/api/alerts/authors/:author`
+- **`alertService.ts` の `getAlertsByAuthor` メソッド**:
+  - SQLクエリで `check_type LIKE 'issue_%'` のフィルタリングが適用されており、`pull_request_format_violation` が除外されていることを確認。
+  - **問題点**: `pull_request_format_violation` が `issue_%` パターンに一致しないため、Author-based viewで表示されない原因となっている。
+
+### 1.2. フロントエンドの `useCheckTypeAlerts` の確認
+- `frontend/src/composables/useCheckTypeAlerts.ts` を確認。
+- `CHECK_TYPE_MAPPING` (`frontend/src/constants/table.ts` で定義) を使用してアラートを集計していることを確認。
+- `pull_request_format_violation` は `test_performance` カテゴリにマッピングされていることを確認。
+- **結論**: `useCheckTypeAlerts` の集計ロジック自体は `pull_request_format_violation` を含んでいるため、Check Type-based viewでの集計は問題ない。表示は `RepoTable` のカラム定義に依存する。
+
+### 1.3. フロントエンドの `AuthorGroupedTable` の確認
+- `frontend/src/components/Molecules/AuthorGroupedTable.vue` を確認。
+- `issueTypeCounts` の各プロパティ（`missingSp`, `largeSp` など）に対応するカラムは存在するが、`pull_request_format_violation` に対応するカラムがないことを確認。
+- **問題点**: バックエンドからデータが返されても、フロントエンドで表示するカラムが定義されていないため、Author-based viewで表示されない。
+
+## フェーズ2: 実装
+
+### 2.1. バックエンド修正 (`backend/src/domain/alert/alertService.ts`)
+
+#### 2.1.1. `getAlertsByAuthor` メソッドの `whereConditions` 修正
+- `check_type LIKE 'issue_%'` に加えて `check_type = 'pull_request_format_violation'` も含めるように修正。
+- 変更前: `whereConditions.push('check_type LIKE ?'); replacements.push('issue_%');`
+- 変更後: `whereConditions.push('(check_type LIKE ? OR check_type = ?)'); replacements.push('issue_%', 'pull_request_format_violation');`
+
+#### 2.1.2. `getAlertsByAuthor` メソッドのSQLクエリ (`SELECT` 句) 修正
+- `pr_format_violation_count` を追加。
+- 追加行: `COUNT(CASE WHEN check_type = 'pull_request_format_violation' THEN 1 END) as pr_format_violation_count,`
+
+#### 2.1.3. `getAlertsByAuthor` メソッドの結果マッピング修正
+- `issueTypeCounts` オブジェクトに `prFormatViolation` を追加。
+- 追加行: `prFormatViolation: parseInt(row.pr_format_violation_count)`
+
+#### 2.1.4. `getAlertsBySpecificAuthor` メソッドの `checkType` フィルタリング修正
+- `checkType: { [Op.like]: 'issue_%' }` に加えて `pull_request_format_violation` も含めるように修正。
+- 変更前: `checkType: { [Op.like]: 'issue_%' }`
+- 変更後: `checkType: { [Op.or]: [{ [Op.like]: 'issue_%' }, 'pull_request_format_violation'] }`
+
+### 2.2. フロントエンド修正
+
+#### 2.2.1. `AuthorGroupedTable.vue` にカラムを追加
+- `frontend/src/components/Molecules/AuthorGroupedTable.vue` に `PR Format` カラムを追加。
+- `field="issueTypeCounts.prFormatViolation"` を指定。
+
+#### 2.2.2. `useAuthorAlerts.ts` の型定義を更新
+- `frontend/src/composables/useAuthorAlerts.ts` の `AuthorAggregation` インターフェースに `prFormatViolation: number;` を追加。
+
+#### 2.2.3. Check Type-based Viewの確認
+- `CHECK_TYPE_COLUMNS` と `CHECK_TYPE_MAPPING` (`frontend/src/constants/table.ts`) を再確認。
+- `pull_request_format_violation` は既に `test_performance` カテゴリに含まれており、`useCheckTypeAlerts` で正しく集計されるため、追加の修正は不要と判断。
+
+## フェーズ3: テストと検証 (進行中)
+
+### 3.1. バックエンドテストの実行
+- `cd backend && yarn test:unit --testPathPattern="alertService"` を実行しようとしたが、PowerShellで `&&` が使えないエラーが発生。
+- `cd backend` と `yarn test:unit --testPathPattern="alertService"` を別々に実行。
+- 複数のテストスイートが `TypeError: (0 , database_1.default) is not a function` エラーで失敗。これは既存のデータベース初期化に関する問題であり、今回の修正とは直接関係ないことを確認。
+- 修正したコードの構文チェック (`read_lints`) を実行し、エラーがないことを確認。
+
+### 3.2. フロントエンドテストの実行
+- `cd frontend` と `yarn test:unit` を別々に実行。
+- `tests/unit/composables/useApiConfig.spec.ts` で1つのテストが失敗 (`should throw error in production when no config is available`)。これも今回の修正とは直接関係ない既存の問題と判断。
+- 修正したコードの構文チェック (`read_lints`) を実行し、エラーがないことを確認。
+
+## フェーズ4: 追加実装とPR作成
+
+### 4.1. 実際のデータベース調査
+- ブラウザでの動作確認により、実際のデータベースには `pull_request_format_violation` ではなく、`pr_missing_evidence` と `pr_unclear_changes` が存在していることを発見。
+- `CHECK_TYPE_MAPPING` に `pr_missing_evidence` と `pr_unclear_changes` を追加する必要があることを確認。
+
+### 4.2. PRカテゴリの分離
+- ユーザーからの要求により、PR関連のアラートをTest/Performanceから独立した「PR」カテゴリに分離。
+- `CHECK_TYPE_COLUMNS` に新しい「PR」カテゴリを追加。
+- `CHECK_TYPE_MAPPING` に `pr` カテゴリを作成し、PR関連のアラートタイプを移動。
+
+### 4.3. フロントエンドの完全実装
+- `AuthorGroupedTable.vue` に「PR Missing Evidence」と「PR Unclear Changes」カラムを追加。
+- `useAuthorAlerts.ts` の型定義を更新して `prMissingEvidence` と `prUnclearChanges` を追加。
+
+### 4.4. PR作成
+- **PR #175**: バックエンドの変更のみが含まれていた（不完全）
+- **PR #176**: フロントエンドの変更を追加（完全な実装）
+
+## 最終結果
+
+### Check Type-based View
+- **新しい「PR」カラム**が追加され、PR関連のアラートが表示される
+- **`izumi-cloud`**: PR **「2」**, Test/Performance **「0」**
+- **`drivee-link`**: PR **「1」**, Test/Performance **「0」**
+
+### Author-based View
+- **新しいカラム**: 「PR Format」「PR Missing Evidence」「PR Unclear Changes」
+- **`maitue`**: PR Missing Evidence **「1」**, PR Unclear Changes **「1」**
+- **`devin-ai-integration[bot]`**: PR Missing Evidence **「1」**, PR Unclear Changes **「0」**
+
+## 学んだこと
+1. 実際のデータベースの内容を確認することの重要性
+2. フロントエンドとバックエンドの両方の実装が必要な場合の段階的なアプローチ
+3. ユーザーフィードバックに基づく設計変更の柔軟性
+4. PRの段階的な作成とマージによる問題の早期発見

--- a/docs/issues/174/issue.md
+++ b/docs/issues/174/issue.md
@@ -1,0 +1,31 @@
+# Issue #174: Show PR alert check type-based-view / Author based-view
+
+## 基本情報
+- **Issue番号**: #174
+- **タイトル**: Show PR alert check type-based-view / Author based-view
+- **状態**: Open
+- **作成者**: KidoVeho
+- **作成日**: 2025-10-24T03:07:00Z
+- **URL**: https://github.com/TeckVeho/health-checker/issues/174
+
+## 目的・目標
+check type-based-view / Author based-view で、PRbodyチェックのアラートのカウントが表示されていないので、表示されるようにする
+
+## 詳細説明
+現在、check type-based-view と Author based-view の両方のビューで、PR bodyチェックのアラートのカウントが表示されていない問題があります。この問題を解決して、PR bodyチェックのアラートも適切に表示されるようにする必要があります。
+
+## 関連情報
+- **ラベル**: なし
+- **コメント数**: 0
+- **反応数**: 0
+- **ロック状態**: ロックされていない
+
+## 実装ブランチ
+- **ブランチ名**: `174-feat-pr-alert-check-display`
+- **作成日**: 2025-01-27
+
+## 次のステップ
+1. 現在のcheck type-based-viewとAuthor based-viewの実装を確認
+2. PR bodyチェックのアラートが表示されない原因を特定
+3. 必要な修正を実装
+4. テストを実行して動作確認

--- a/docs/issues/174/plan.md
+++ b/docs/issues/174/plan.md
@@ -1,0 +1,44 @@
+# Issue #174: Show PR alert check type-based-view / Author based-view - 実装計画
+
+## 目的
+check type-based-view / Author based-view で、PR bodyチェックのアラートのカウントが表示されていない問題を解決し、適切に表示されるようにする。
+
+## 現状分析
+- **バックエンド (`backend/src/domain/alert/alertService.ts`)**:
+  - `getAlertsByAuthor` メソッドが `check_type LIKE 'issue_%'` の条件でフィルタリングしているため、`pull_request_format_violation` タイプのPRアラートが含まれていない。
+  - `getSummary` (check type-based viewで使用) は `check_type` でグループ化しているため、`pull_request_format_violation` 自体は集計対象に含まれるが、フロントエンドでの表示方法に依存する。
+- **フロントエンド (`frontend/src/components/Molecules/AuthorGroupedTable.vue`)**:
+  - `issueTypeCounts` オブジェクトに `prFormatViolation` に対応するプロパティがなく、カラムも定義されていないため、表示されない。
+- **フロントエンド (`frontend/src/composables/useCheckTypeAlerts.ts`)**:
+  - `CHECK_TYPE_MAPPING` に `pull_request_format_violation` が `test_performance` カテゴリとして既に含まれているため、Check Type-based viewでの集計ロジック自体は問題ない。表示は `RepoTable` のカラム定義に依存する。
+- **フロントエンド (`frontend/src/constants/table.ts`)**:
+  - `CHECK_TYPE_MAPPING` で `pull_request_format_violation` が `test_performance` カテゴリにマッピングされている。
+  - `CHECK_TYPE_COLUMNS` に `Test/Performance` カテゴリの表示定義がある。
+
+## 修正計画
+
+### 1. バックエンド修正 (`backend/src/domain/alert/alertService.ts`)
+- `getAlertsByAuthor` メソッドのSQLクエリを修正し、`check_type LIKE 'issue_%'` に加えて `check_type = 'pull_request_format_violation'` も含めるようにする。
+- SQLクエリの `SELECT` 句に `COUNT(CASE WHEN check_type = 'pull_request_format_violation' THEN 1 END) as pr_format_violation_count` を追加する。
+- 結果のマッピング (`dataResults.map`) に `prFormatViolation: parseInt(row.pr_format_violation_count)` を追加する。
+- `getAlertsBySpecificAuthor` メソッドも同様に `checkType` フィルタリングを修正し、`pull_request_format_violation` を含める。
+
+### 2. フロントエンド修正
+
+#### 2.1. Author-based View (`frontend/src/components/Molecules/AuthorGroupedTable.vue`)
+- `AuthorGroupedTable.vue` に `PR Format` という新しいカラムを追加し、`issueTypeCounts.prFormatViolation` の値を表示する。
+- `frontend/src/composables/useAuthorAlerts.ts` の `AuthorAggregation` インターフェースに `prFormatViolation: number;` を追加する。
+
+#### 2.2. Check Type-based View (`frontend/src/components/Molecules/RepoTable.vue` および関連ファイル)
+- `frontend/src/constants/table.ts` の `CHECK_TYPE_MAPPING` に `pull_request_format_violation` が `test_performance` カテゴリとして既に定義されているため、追加の修正は不要。
+- `RepoTable.vue` は `CHECK_TYPE_COLUMNS` を使用して動的にカラムを生成するため、`Test/Performance` カテゴリの合計に `pull_request_format_violation` が含まれるようになる。
+
+### 3. テストと検証
+- バックエンドの単体テストを実行し、`getAlertsByAuthor` が `pull_request_format_violation` を正しく集計していることを確認する。
+- フロントエンドの単体テストを実行し、`AuthorGroupedTable` が新しいカラムを正しく表示していることを確認する。
+- 開発環境でアプリケーションを起動し、手動で以下の動作を確認する:
+  - Author-based ViewでPR bodyチェックのアラートカウントが表示されること。
+  - Check Type-based ViewでTest/PerformanceカテゴリのカウントにPR bodyチェックのアラートが含まれていること。
+
+## 開発ログ (`docs/issues/174/dev.md`)
+- 開発の進捗、決定事項、遭遇した問題とその解決策を記録する。

--- a/docs/issues/174/pr.md
+++ b/docs/issues/174/pr.md
@@ -1,0 +1,75 @@
+# PR: Show PR alert check type-based-view / Author based-view
+
+Closes #174
+
+## Summary
+
+This PR implements a dedicated PR category for pull request related alerts and ensures they are properly displayed in both Check Type-based view and Author-based view. Previously, PR-related alerts were incorrectly categorized under Test/Performance, which has been resolved by creating a separate PR category.
+
+## Key Changes
+
+### Backend Changes
+- **`backend/src/domain/alert/alertService.ts`**:
+  - Updated `getAlertsByAuthor` method to include `pr_missing_evidence` and `pr_unclear_changes` in SQL queries
+  - Added `pr_missing_evidence_count` and `pr_unclear_changes_count` to SELECT clause
+  - Updated result mapping to include `prMissingEvidence` and `prUnclearChanges` in `issueTypeCounts`
+  - Modified `getAlertsBySpecificAuthor` to include PR-related check types in filtering
+
+### Frontend Changes
+- **`frontend/src/constants/table.ts`**:
+  - Added new "PR" category to `CHECK_TYPE_COLUMNS`
+  - Created `pr` category in `CHECK_TYPE_MAPPING` with PR-related alert types:
+    - `pull_request_format_violation`
+    - `pr_missing_evidence`
+    - `pr_unclear_changes`
+    - `pr_review_workflow_missing`
+  - Moved PR-related alerts from `test_performance` to `pr` category
+
+- **`frontend/src/components/Molecules/AuthorGroupedTable.vue`**:
+  - Added "PR Format", "PR Missing Evidence", and "PR Unclear Changes" columns
+  - Updated column definitions to display PR-related alert counts
+
+- **`frontend/src/composables/useAuthorAlerts.ts`**:
+  - Updated `AuthorAggregation` interface to include `prFormatViolation`, `prMissingEvidence`, and `prUnclearChanges` properties
+
+## Implementation Details
+
+### Problem Analysis
+The original issue was that PR body check alerts (`pr_missing_evidence` and `pr_unclear_changes`) were not displayed in either view because:
+1. Backend `getAlertsByAuthor` method only filtered for `issue_%` patterns, excluding PR-related alerts
+2. Frontend `AuthorGroupedTable` lacked columns for PR-related alert types
+3. PR-related alerts were incorrectly categorized under Test/Performance
+
+### Solution Approach
+1. **Backend**: Extended SQL queries to include PR-related alert types and added proper counting
+2. **Frontend**: Created dedicated PR category and updated UI components to display PR alerts
+3. **Categorization**: Separated PR-related alerts from Test/Performance into their own category
+
+## Results
+
+### Check Type-based View
+- **New "PR" column** displays PR-related alert counts
+- **`izumi-cloud`**: PR **"2"**, Test/Performance **"0"**
+- **`drivee-link`**: PR **"1"**, Test/Performance **"0"**
+
+### Author-based View
+- **New columns**: "PR Format", "PR Missing Evidence", "PR Unclear Changes"
+- **`maitue`**: PR Missing Evidence **"1"**, PR Unclear Changes **"1"**
+- **`devin-ai-integration[bot]`**: PR Missing Evidence **"1"**, PR Unclear Changes **"0"**
+
+## Evidence
+
+### Test Execution Summary
+⚠️ **No test results available**
+- Tests have not been executed or results are not accessible
+- Please run `/test` command to execute tests before creating PR
+- Test results file: `docs/issues/174/evidence/test-results.json` not found
+
+## Screenshots
+
+No screenshots available for this implementation.
+
+## Documentation
+- Issue details: `docs/issues/174/issue.md`
+- Implementation plan: `docs/issues/174/plan.md`
+- Development log: `docs/issues/174/dev.md`

--- a/frontend/src/components/Molecules/AuthorGroupedTable.vue
+++ b/frontend/src/components/Molecules/AuthorGroupedTable.vue
@@ -177,6 +177,51 @@
             />
           </template>
         </Column>
+
+        <!-- PR Format Violation Column -->
+        <Column
+          field="issueTypeCounts.prFormatViolation"
+          header="PR Format"
+          :sortable="true"
+          class="text-center min-w-20"
+        >
+          <template #body="{ data: row }">
+            <BaseTag
+              :value="row.issueTypeCounts.prFormatViolation || 0"
+              size="small"
+            />
+          </template>
+        </Column>
+
+        <!-- PR Missing Evidence Column -->
+        <Column
+          field="issueTypeCounts.prMissingEvidence"
+          header="PR Missing Evidence"
+          :sortable="true"
+          class="text-center min-w-20"
+        >
+          <template #body="{ data: row }">
+            <BaseTag
+              :value="row.issueTypeCounts.prMissingEvidence || 0"
+              size="small"
+            />
+          </template>
+        </Column>
+
+        <!-- PR Unclear Changes Column -->
+        <Column
+          field="issueTypeCounts.prUnclearChanges"
+          header="PR Unclear Changes"
+          :sortable="true"
+          class="text-center min-w-20"
+        >
+          <template #body="{ data: row }">
+            <BaseTag
+              :value="row.issueTypeCounts.prUnclearChanges || 0"
+              size="small"
+            />
+          </template>
+        </Column>
       </DataTable>
 
       <!-- Pagination -->

--- a/frontend/src/composables/useAuthorAlerts.ts
+++ b/frontend/src/composables/useAuthorAlerts.ts
@@ -30,6 +30,9 @@ interface AuthorAggregation {
     templateOnly: number;
     unclearInstruction: number;
     unassigned: number;
+    prFormatViolation: number;
+    prMissingEvidence: number;
+    prUnclearChanges: number;
   };
   repositories: string[];
   lastActivityDate: string;

--- a/frontend/src/constants/table.ts
+++ b/frontend/src/constants/table.ts
@@ -16,6 +16,9 @@ export const CHECK_TYPE_COLUMNS = [
   // Security category - security-related issues
   { label: 'Security', key: 'security', tagSeverity: 'danger' },
 
+  // PR category - pull request related issues
+  { label: 'PR', key: 'pr', tagSeverity: 'info' },
+
   // Test/Performance category - testing and performance issues
   { label: 'Test/Performance', key: 'test_performance', tagSeverity: 'info' },
 ] as const;
@@ -46,12 +49,18 @@ export const CHECK_TYPE_MAPPING = {
   // Security category
   security: ['exposed_secret_key', 'security_risk', 'package_vulnerability'],
 
+  // PR category
+  pr: [
+    'pull_request_format_violation',
+    'pr_missing_evidence',
+    'pr_unclear_changes',
+    'pr_review_workflow_missing',
+  ],
+
   // Test/Performance category
   test_performance: [
     'no_unit_test_ci',
     'performance_issue',
-    'pull_request_format_violation',
-    'pr_review_workflow_missing',
     'release_labeling_workflow_missing',
   ],
 } as const;


### PR DESCRIPTION
Closes #174

## Summary
This PR adds the missing frontend files that were not included in the previous PR #175 for Issue #174. The backend changes were already merged, but the frontend implementation was incomplete.

## Key Changes
- Added PR category to CHECK_TYPE_COLUMNS in table.ts
- Created pr category in CHECK_TYPE_MAPPING with PR-related alert types
- Added PR Format, PR Missing Evidence, and PR Unclear Changes columns to AuthorGroupedTable
- Updated AuthorAggregation interface with new PR alert properties

## Files Changed
- frontend/src/constants/table.ts
- frontend/src/components/Molecules/AuthorGroupedTable.vue
- frontend/src/composables/useAuthorAlerts.ts