### PR TITLE
feat: PRにissueが紐づいていない場合の violation (pr_issue_not_linked) (#178)

### DIFF
--- a/backend/src/domain/alert/alertService.ts
+++ b/backend/src/domain/alert/alertService.ts
@@ -525,9 +525,14 @@ class AlertService {
     return { owner, repo };
   }
 
-  static async processPullRequestAlerts(owner: string, repo: string, processStartTime?: Date): Promise<{ owner: string; repo: string }> {
+  static async processPullRequestAlerts(
+    owner: string,
+    repo: string,
+    processStartTime?: Date,
+    isScheduledRun = false
+  ): Promise<{ owner: string; repo: string }> {
     const timestamp = new Date();
-    const result = await checkPullRequests(owner, repo);
+    const result = await checkPullRequests(owner, repo, undefined, { isScheduledRun });
     const detectedKeySet = new Set<string>();
 
     // Process new alerts
@@ -577,7 +582,11 @@ class AlertService {
       });
     }
 
-    // Resolve old alerts that are no longer detected
+    // Resolve old alerts that are no longer detected (scheduled runのみ pr_issue_not_linked を解消対象に含める)
+    const prQualityCheckTypes: string[] = ['pr_unclear_changes', 'pr_missing_evidence'];
+    if (isScheduledRun) {
+      prQualityCheckTypes.push('pr_issue_not_linked');
+    }
     await Alert.update(
       {
         systemResolved: true,
@@ -588,7 +597,7 @@ class AlertService {
         where: {
           owner,
           repo,
-          checkType: ['pr_unclear_changes', 'pr_missing_evidence'],
+          checkType: prQualityCheckTypes,
           systemResolved: false,
           lastDetectedAt: processStartTime ? { [Op.lt]: processStartTime } : { [Op.lt]: timestamp },
         },
@@ -603,6 +612,8 @@ class AlertService {
       owner: string; 
       repo: string; 
       checks?: string[];
+      /** 定期チェック（cron 等）のとき true。PR↔issue 紐づきチェックはこのときのみ実行 */
+      isScheduledRun?: boolean;
       onProgress?: (progress: {
         currentPhase: string;
         totalPhases: number;
@@ -616,7 +627,7 @@ class AlertService {
       }) => void;
     }
   ): Promise<Record<string, unknown>> {
-    const { owner, repo, checks, onProgress } = options;
+    const { owner, repo, checks, onProgress, isScheduledRun = false } = options;
     const effectiveChecks = checks ?? ['branch', 'clone', 'gitleaks', 'issue', 'pr'];
     const results: Record<string, unknown> = {};
     const totalPhases = effectiveChecks.length;
@@ -687,7 +698,7 @@ class AlertService {
 
     if (effectiveChecks.includes('pr')) {
       updateProgress('Pull Request Analysis', 0);
-      await this.processPullRequestAlerts(owner, repo, processStartTime);
+      await this.processPullRequestAlerts(owner, repo, processStartTime, isScheduledRun);
       updateProgress('Pull Request Analysis', 100);
       results.pr = 'checked';
       currentPhaseIndex++;
@@ -751,7 +762,12 @@ class AlertService {
           continue;
         }
 
-        const result = await this.runAlert({ owner: repoOwner, repo: repoName, checks });
+        const result = await this.runAlert({
+          owner: repoOwner,
+          repo: repoName,
+          checks,
+          isScheduledRun: true,
+        });
         results.push({ repo: repoName, ...result });
       } catch (err) {
         console.error(`❌ Failed to process ${repoName}`, err);
@@ -793,8 +809,16 @@ class AlertService {
     const replacements: (string | number)[] = [];
 
     // Filter for Issue type alerts and PR format violations (author-related issues and PR checks)
-    whereConditions.push('(check_type LIKE ? OR check_type = ? OR check_type = ? OR check_type = ?)');
-    replacements.push('issue_%', 'pull_request_format_violation', 'pr_missing_evidence', 'pr_unclear_changes');
+    whereConditions.push(
+      '(check_type LIKE ? OR check_type = ? OR check_type = ? OR check_type = ? OR check_type = ?)'
+    );
+    replacements.push(
+      'issue_%',
+      'pull_request_format_violation',
+      'pr_missing_evidence',
+      'pr_unclear_changes',
+      'pr_issue_not_linked'
+    );
 
     if (owner) {
       whereConditions.push('owner = ?');
@@ -835,6 +859,7 @@ class AlertService {
         COUNT(CASE WHEN check_type = 'pull_request_format_violation' THEN 1 END) as pr_format_violation_count,
         COUNT(CASE WHEN check_type = 'pr_missing_evidence' THEN 1 END) as pr_missing_evidence_count,
         COUNT(CASE WHEN check_type = 'pr_unclear_changes' THEN 1 END) as pr_unclear_changes_count,
+        COUNT(CASE WHEN check_type = 'pr_issue_not_linked' THEN 1 END) as pr_issue_not_linked_count,
         GROUP_CONCAT(DISTINCT owner || '/' || repo) as repositories,
         MAX(last_detected_at) as last_activity_date
       FROM alerts 
@@ -888,7 +913,8 @@ class AlertService {
         unassigned: parseInt(row.unassigned_count),
         prFormatViolation: parseInt(row.pr_format_violation_count),
         prMissingEvidence: parseInt(row.pr_missing_evidence_count),
-        prUnclearChanges: parseInt(row.pr_unclear_changes_count)
+        prUnclearChanges: parseInt(row.pr_unclear_changes_count),
+        prIssueNotLinked: parseInt(row.pr_issue_not_linked_count)
       },
       repositories: row.repositories ? row.repositories.split(',') : [],
       lastActivityDate: row.last_activity_date
@@ -925,7 +951,8 @@ class AlertService {
           { [Op.like]: 'issue_%' },  // Issue-type alerts
           'pull_request_format_violation',  // PR format violations
           'pr_missing_evidence',  // PR missing evidence
-          'pr_unclear_changes'   // PR unclear changes
+          'pr_unclear_changes',  // PR unclear changes
+          'pr_issue_not_linked'  // PR not linked to an issue
         ]
       }
     };

--- a/backend/src/domain/alert/util/checkPullRequests.ts
+++ b/backend/src/domain/alert/util/checkPullRequests.ts
@@ -4,7 +4,7 @@
  */
 
 import { checkPullRequests as checkPullRequestsInternal } from './checkPullRequests/index';
-import { CheckPullRequestsResult } from './checkPullRequests/types';
+import { CheckPullRequestsResult, CheckPullRequestsOptions } from './checkPullRequests/types';
 
 /**
  * Main function to check pull requests for various problems
@@ -13,10 +13,15 @@ import { CheckPullRequestsResult } from './checkPullRequests/types';
 export async function checkPullRequests(
   owner: string,
   repo: string,
-  onProgress?: (processed: number, total: number) => void
+  onProgress?: (processed: number, total: number) => void,
+  options?: CheckPullRequestsOptions
 ): Promise<CheckPullRequestsResult> {
-  return await checkPullRequestsInternal(owner, repo, onProgress);
+  return await checkPullRequestsInternal(owner, repo, onProgress, options);
 }
 
 // Re-export types for backward compatibility
-export type { CheckPullRequestsResult, PullRequestAlertCandidate } from './checkPullRequests/types';
+export type {
+  CheckPullRequestsResult,
+  PullRequestAlertCandidate,
+  CheckPullRequestsOptions,
+} from './checkPullRequests/types';

--- a/backend/src/domain/alert/util/checkPullRequests/github.ts
+++ b/backend/src/domain/alert/util/checkPullRequests/github.ts
@@ -2,6 +2,7 @@
  * GitHub API operations for pull request data
  */
 import { Octokit } from '@octokit/rest';
+import { subDays } from 'date-fns';
 import { GitHubPullRequest } from './types';
 
 const githubToken = process.env.GITHUB_API_KEY;
@@ -10,6 +11,32 @@ if (!githubToken) throw new Error('GITHUB_API_KEY is required');
 const octokit = new Octokit({
   auth: githubToken,
 });
+
+function mapRestPullRequest(pr: {
+  number: number;
+  title: string;
+  body: string | null;
+  user: { login?: string | null } | null;
+  head: { ref: string };
+  html_url: string;
+  created_at: string;
+  updated_at: string;
+}): GitHubPullRequest {
+  return {
+    number: pr.number,
+    title: pr.title,
+    body: pr.body,
+    user: {
+      login: pr.user?.login || 'unknown',
+    },
+    head: {
+      ref: pr.head.ref,
+    },
+    html_url: pr.html_url,
+    created_at: pr.created_at,
+    updated_at: pr.updated_at,
+  };
+}
 
 /**
  * Fetch all open pull requests for a repository
@@ -27,20 +54,7 @@ export async function fetchOpenPullRequests(owner: string, repo: string): Promis
       per_page: 100, // GitHub API limit
     });
 
-    const pullRequests: GitHubPullRequest[] = response.data.map(pr => ({
-      number: pr.number,
-      title: pr.title,
-      body: pr.body,
-      user: {
-        login: pr.user?.login || 'unknown',
-      },
-      head: {
-        ref: pr.head.ref,
-      },
-      html_url: pr.html_url,
-      created_at: pr.created_at,
-      updated_at: pr.updated_at,
-    }));
+    const pullRequests: GitHubPullRequest[] = response.data.map(mapRestPullRequest);
 
     console.log(`  Retrieved ${pullRequests.length} open pull requests`);
     return pullRequests;
@@ -48,6 +62,118 @@ export async function fetchOpenPullRequests(owner: string, repo: string): Promis
     console.error(`❌ Failed to fetch pull requests for ${owner}/${repo}:`, error);
     throw error;
   }
+}
+
+/**
+ * Closed PRs whose created_at is within the last `days` days (for scheduled checks).
+ */
+export async function fetchRecentlyClosedPullRequestsCreatedWithin(
+  owner: string,
+  repo: string,
+  days: number
+): Promise<GitHubPullRequest[]> {
+  const cutoff = subDays(new Date(), days);
+  const cutoffMs = cutoff.getTime();
+  const result: GitHubPullRequest[] = [];
+  let page = 1;
+  const perPage = 100;
+
+  console.log(`  Fetching closed pull requests (created within ${days}d) for ${owner}/${repo}...`);
+
+  try {
+    while (true) {
+      const response = await octokit.pulls.list({
+        owner,
+        repo,
+        state: 'closed',
+        sort: 'created',
+        direction: 'desc',
+        per_page: perPage,
+        page,
+      });
+
+      if (response.data.length === 0) {
+        break;
+      }
+
+      let stopPagination = false;
+      for (const pr of response.data) {
+        const createdMs = new Date(pr.created_at).getTime();
+        if (createdMs < cutoffMs) {
+          stopPagination = true;
+          break;
+        }
+        result.push(mapRestPullRequest(pr));
+      }
+
+      if (stopPagination || response.data.length < perPage) {
+        break;
+      }
+      page++;
+    }
+
+    console.log(`  Retrieved ${result.length} recently created closed pull requests`);
+    return result;
+  } catch (error) {
+    console.error(`❌ Failed to fetch closed pull requests for ${owner}/${repo}:`, error);
+    throw error;
+  }
+}
+
+/**
+ * Open PRs plus closed PRs created within the last 7 days (scheduled / cron checks).
+ */
+export async function fetchPullRequestsForScheduledCheck(owner: string, repo: string): Promise<GitHubPullRequest[]> {
+  const [open, closedRecent] = await Promise.all([
+    fetchOpenPullRequests(owner, repo),
+    fetchRecentlyClosedPullRequestsCreatedWithin(owner, repo, 7),
+  ]);
+
+  const byNumber = new Map<number, GitHubPullRequest>();
+  for (const pr of open) {
+    byNumber.set(pr.number, pr);
+  }
+  for (const pr of closedRecent) {
+    if (!byNumber.has(pr.number)) {
+      byNumber.set(pr.number, pr);
+    }
+  }
+
+  const merged = Array.from(byNumber.values());
+  console.log(`  Scheduled PR check: ${merged.length} total (open + recently created closed)`);
+  return merged;
+}
+
+/**
+ * Count GitHub "closing issues" references (Linked issues / development references) for a PR.
+ */
+export async function getClosingIssuesReferenceCount(owner: string, repo: string, prNumber: number): Promise<number> {
+  const response = await octokit.graphql<{
+    repository: {
+      pullRequest: {
+        closingIssuesReferences: { totalCount: number };
+      } | null;
+    } | null;
+  }>(
+    `
+    query GetClosingIssuesRefCount($owner: String!, $repo: String!, $prNumber: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $prNumber) {
+          closingIssuesReferences(first: 1) {
+            totalCount
+          }
+        }
+      }
+    }
+    `,
+    { owner, repo, prNumber }
+  );
+
+  const pr = response.repository?.pullRequest;
+  if (!pr) {
+    return 0;
+  }
+  return pr.closingIssuesReferences?.totalCount ?? 0;
 }
 
 /**
@@ -62,24 +188,9 @@ export async function getPullRequestDetails(owner: string, repo: string, prNumbe
     });
 
     const pr = response.data;
-    return {
-      number: pr.number,
-      title: pr.title,
-      body: pr.body,
-      user: {
-        login: pr.user?.login || 'unknown',
-      },
-      head: {
-        ref: pr.head.ref,
-      },
-      html_url: pr.html_url,
-      created_at: pr.created_at,
-      updated_at: pr.updated_at,
-    };
+    return mapRestPullRequest(pr);
   } catch (error) {
     console.error(`❌ Failed to fetch PR #${prNumber} for ${owner}/${repo}:`, error);
     return null;
   }
 }
-
-

--- a/backend/src/domain/alert/util/checkPullRequests/index.ts
+++ b/backend/src/domain/alert/util/checkPullRequests/index.ts
@@ -2,10 +2,14 @@
  * Main orchestrator for checkPullRequests functionality
  * Coordinates all modules while maintaining the original public API
  */
-import { CheckPullRequestsResult, PullRequestAlertCandidate, GitHubPullRequest } from './types';
-import { fetchOpenPullRequests } from './github';
-import { validatePRQuality } from './validators';
-import { analyzePRWithLLM } from './llm';
+import {
+  CheckPullRequestsResult,
+  CheckPullRequestsOptions,
+  PullRequestAlertCandidate,
+  GitHubPullRequest,
+} from './types';
+import { fetchOpenPullRequests, fetchPullRequestsForScheduledCheck } from './github';
+import { validatePRQuality, validatePrIssueLinked } from './validators';
 
 /**
  * Main function to check pull requests for various problems
@@ -14,29 +18,38 @@ import { analyzePRWithLLM } from './llm';
 export async function checkPullRequests(
   owner: string,
   repo: string,
-  onProgress?: (processed: number, total: number) => void
+  onProgress?: (processed: number, total: number) => void,
+  options?: CheckPullRequestsOptions
 ): Promise<CheckPullRequestsResult> {
   const alerts: PullRequestAlertCandidate[] = [];
+  const isScheduledRun = options?.isScheduledRun === true;
 
   try {
-    // Fetch open pull requests
-    const pullRequests = await fetchOpenPullRequests(owner, repo);
-    console.log(`  Found ${pullRequests.length} open pull requests in ${owner}/${repo}`);
+    const pullRequests: GitHubPullRequest[] = isScheduledRun
+      ? await fetchPullRequestsForScheduledCheck(owner, repo)
+      : await fetchOpenPullRequests(owner, repo);
 
-    // Process each pull request
+    console.log(
+      `  Found ${pullRequests.length} pull requests to process in ${owner}/${repo}` +
+        (isScheduledRun ? ' (scheduled: open + recent closed)' : '')
+    );
+
     for (let i = 0; i < pullRequests.length; i++) {
       const pr = pullRequests[i];
 
       console.log(`  Processing PR #${pr.number} (${i + 1}/${pullRequests.length})`);
 
-      // Report progress to callback
       if (onProgress) {
         onProgress(i + 1, pullRequests.length);
       }
 
-      // Run PR quality validations
       const prAlerts = await validatePRQuality(pr, owner, repo);
       alerts.push(...prAlerts);
+
+      if (isScheduledRun) {
+        const linkAlerts = await validatePrIssueLinked(pr, owner, repo);
+        alerts.push(...linkAlerts);
+      }
     }
 
     console.log(`  Found ${alerts.length} PR alerts for ${owner}/${repo}`);
@@ -46,5 +59,3 @@ export async function checkPullRequests(
 
   return { owner, repo, alerts };
 }
-
-

--- a/backend/src/domain/alert/util/checkPullRequests/types.ts
+++ b/backend/src/domain/alert/util/checkPullRequests/types.ts
@@ -38,6 +38,12 @@ export interface CheckPullRequestsResult {
   alerts: PullRequestAlertCandidate[];
 }
 
+/** Options for `checkPullRequests` */
+export interface CheckPullRequestsOptions {
+  /** When true, include recently closed PRs and run `pr_issue_not_linked` (scheduled/cron runs only). */
+  isScheduledRun?: boolean;
+}
+
 export interface LLMAnalysisResult {
   unclearChanges: boolean;
   missingEvidence: boolean;

--- a/backend/src/domain/alert/util/checkPullRequests/validators.ts
+++ b/backend/src/domain/alert/util/checkPullRequests/validators.ts
@@ -1,8 +1,9 @@
 /**
  * Business rule validation logic for pull requests
  */
-import { GitHubPullRequest, PullRequestAlertCandidate, LLMAnalysisResult } from './types';
+import { GitHubPullRequest, PullRequestAlertCandidate } from './types';
 import { analyzePRWithLLM } from './llm';
+import { getClosingIssuesReferenceCount } from './github';
 
 /**
  * Create an alert candidate with common fields
@@ -80,5 +81,34 @@ export async function validatePRQuality(
     // Continue processing other PRs even if one fails
   }
 
+  return alerts;
+}
+
+/**
+ * PR に Linked issues（closing references）が1件も無い場合にアラート
+ */
+export async function validatePrIssueLinked(
+  pr: GitHubPullRequest,
+  owner: string,
+  repo: string
+): Promise<PullRequestAlertCandidate[]> {
+  const alerts: PullRequestAlertCandidate[] = [];
+  try {
+    const count = await getClosingIssuesReferenceCount(owner, repo, pr.number);
+    if (count === 0) {
+      alerts.push(
+        createAlert(
+          pr,
+          owner,
+          repo,
+          'pr_issue_not_linked',
+          `PR has no linked issues (GitHub linked / closing issue references) PR#${pr.number}`,
+          'middle'
+        )
+      );
+    }
+  } catch (error) {
+    console.error(`❌ Error checking linked issues for PR #${pr.number}:`, error);
+  }
   return alerts;
 }

--- a/frontend/src/components/Molecules/AuthorGroupedTable.vue
+++ b/frontend/src/components/Molecules/AuthorGroupedTable.vue
@@ -222,6 +222,21 @@
             />
           </template>
         </Column>
+
+        <!-- PR Not Linked to Issue -->
+        <Column
+          field="issueTypeCounts.prIssueNotLinked"
+          header="Not Linked PR"
+          :sortable="true"
+          class="text-center min-w-20"
+        >
+          <template #body="{ data: row }">
+            <BaseTag
+              :value="row.issueTypeCounts.prIssueNotLinked || 0"
+              size="small"
+            />
+          </template>
+        </Column>
       </DataTable>
 
       <!-- Pagination -->

--- a/frontend/src/composables/useAuthorAlerts.ts
+++ b/frontend/src/composables/useAuthorAlerts.ts
@@ -33,6 +33,7 @@ interface AuthorAggregation {
     prFormatViolation: number;
     prMissingEvidence: number;
     prUnclearChanges: number;
+    prIssueNotLinked: number;
   };
   repositories: string[];
   lastActivityDate: string;

--- a/frontend/src/constants/table.ts
+++ b/frontend/src/constants/table.ts
@@ -31,6 +31,9 @@ export const CHECK_TYPE_COLUMNS = [
   // PR category - pull request related issues
   { label: 'PR', key: 'pr', tagSeverity: 'info' },
 
+  // PR ↔ issue link (scheduled check only)
+  { label: 'Not Linked PR', key: 'notLinkedPr', tagSeverity: 'info' },
+
   // Test/Performance category - testing and performance issues
   { label: 'Test', key: 'test', tagSeverity: 'info' },
 ] as const;
@@ -84,6 +87,8 @@ export const CHECK_TYPE_MAPPING = {
     'pr_unclear_changes',
     'pr_review_workflow_missing',
   ],
+
+  notLinkedPr: ['pr_issue_not_linked'],
 
   // Test/Performance category
   test: [


### PR DESCRIPTION
## 概要
Issue #178 の実装です。PR に Linked issues（closing issue references）が 1 件もない場合に \pr_issue_not_linked\（middle）でアラートします。

## 動作
- **定期チェック**（\checkStoredRepos\ / \isScheduledRun: true\）のみ: オープン PR ＋ **作成から 7 日以内にクローズ**した PR を対象に紐づき検査
- **ReCheck・手動**では紐づきチェックをスキップ（誤解消・API 節約）
- 紐づきは GraphQL \closingIssuesReferences.totalCount\ で判定

## 変更ファイル
- バックエンド: \checkPullRequests\ 拡張、\AlertService.runAlert\ に \isScheduledRun\、集計 API
- フロント: Check Type 列「Not Linked PR」、著者別テーブル

Closes #178

Made with [Cursor](https://cursor.com)