### PR TITLE
feat: Dependabot オープン PR をアラートとしてカウント (#192)

### DIFF
--- a/backend/src/domain/alert/alertService.ts
+++ b/backend/src/domain/alert/alertService.ts
@@ -583,7 +583,11 @@ class AlertService {
     }
 
     // Resolve old alerts that are no longer detected (scheduled runのみ pr_issue_not_linked を解消対象に含める)
-    const prQualityCheckTypes: string[] = ['pr_unclear_changes', 'pr_missing_evidence'];
+    const prQualityCheckTypes: string[] = [
+      'pr_unclear_changes',
+      'pr_missing_evidence',
+      'dependabot_open_pr',
+    ];
     if (isScheduledRun) {
       prQualityCheckTypes.push('pr_issue_not_linked');
     }

--- a/backend/src/domain/alert/util/checkPullRequests/github.ts
+++ b/backend/src/domain/alert/util/checkPullRequests/github.ts
@@ -21,6 +21,7 @@ function mapRestPullRequest(pr: {
   html_url: string;
   created_at: string;
   updated_at: string;
+  state: string;
 }): GitHubPullRequest {
   return {
     number: pr.number,
@@ -35,6 +36,7 @@ function mapRestPullRequest(pr: {
     html_url: pr.html_url,
     created_at: pr.created_at,
     updated_at: pr.updated_at,
+    state: pr.state === 'closed' ? 'closed' : 'open',
   };
 }
 

--- a/backend/src/domain/alert/util/checkPullRequests/index.ts
+++ b/backend/src/domain/alert/util/checkPullRequests/index.ts
@@ -9,7 +9,7 @@ import {
   GitHubPullRequest,
 } from './types';
 import { fetchOpenPullRequests, fetchPullRequestsForScheduledCheck } from './github';
-import { validatePRQuality, validatePrIssueLinked } from './validators';
+import { validatePRQuality, validatePrIssueLinked, validateDependabotOpenPr } from './validators';
 
 /**
  * Main function to check pull requests for various problems
@@ -45,6 +45,8 @@ export async function checkPullRequests(
 
       const prAlerts = await validatePRQuality(pr, owner, repo);
       alerts.push(...prAlerts);
+
+      alerts.push(...validateDependabotOpenPr(pr, owner, repo));
 
       if (isScheduledRun) {
         const linkAlerts = await validatePrIssueLinked(pr, owner, repo);

--- a/backend/src/domain/alert/util/checkPullRequests/types.ts
+++ b/backend/src/domain/alert/util/checkPullRequests/types.ts
@@ -15,6 +15,8 @@ export interface GitHubPullRequest {
   html_url: string;
   created_at: string;
   updated_at: string;
+  /** REST API `state` — required for open-only checks when mixing open + closed PR lists */
+  state: 'open' | 'closed';
 }
 
 export interface PullRequestAlertCandidate {

--- a/backend/src/domain/alert/util/checkPullRequests/validators.ts
+++ b/backend/src/domain/alert/util/checkPullRequests/validators.ts
@@ -84,13 +84,43 @@ export async function validatePRQuality(
   return alerts;
 }
 
+/** 作成者 login に `dependabot` を含む（大小無視） */
+export function isDependabotAuthor(pr: GitHubPullRequest): boolean {
+  return pr.user.login.toLowerCase().includes('dependabot');
+}
+
 /** pr_issue_not_linked から除外する Dependabot 系 PR（タイトル・作者） */
 function shouldSkipPrIssueNotLinkedForDependabot(pr: GitHubPullRequest): boolean {
   if (pr.title.toLowerCase().includes('dependabot')) {
     return true;
   }
-  const login = pr.user.login.toLowerCase();
-  return login === 'dependabot[bot]' || login === 'dependabot';
+  return isDependabotAuthor(pr);
+}
+
+/**
+ * オープンかつ Dependabot 作成の PR を 1 PR あたり 1 アラートにする（定期・手動の両方）
+ */
+export function validateDependabotOpenPr(
+  pr: GitHubPullRequest,
+  owner: string,
+  repo: string
+): PullRequestAlertCandidate[] {
+  if (pr.state !== 'open') {
+    return [];
+  }
+  if (!isDependabotAuthor(pr)) {
+    return [];
+  }
+  return [
+    createAlert(
+      pr,
+      owner,
+      repo,
+      'dependabot_open_pr',
+      `Open Dependabot PR pending merge/review PR#${pr.number}`,
+      'low'
+    ),
+  ];
 }
 
 /**

--- a/backend/tests/unit/domain/alert/util/checkPullRequests/validators.test.ts
+++ b/backend/tests/unit/domain/alert/util/checkPullRequests/validators.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for PR validators (Dependabot open PR, etc.)
+ */
+import { describe, test, expect } from '@jest/globals';
+import {
+  isDependabotAuthor,
+  validateDependabotOpenPr,
+} from '../../../../../../src/domain/alert/util/checkPullRequests/validators';
+import type { GitHubPullRequest } from '../../../../../../src/domain/alert/util/checkPullRequests/types';
+
+function basePr(overrides: Partial<GitHubPullRequest> = {}): GitHubPullRequest {
+  return {
+    number: 1,
+    title: 'chore(deps): bump foo',
+    body: 'body',
+    user: { login: 'dependabot[bot]' },
+    head: { ref: 'dependabot/npm-foo' },
+    html_url: 'https://github.com/o/r/pull/1',
+    created_at: '2025-01-01T00:00:00Z',
+    updated_at: '2025-01-01T00:00:00Z',
+    state: 'open',
+    ...overrides,
+  };
+}
+
+describe('isDependabotAuthor', () => {
+  test('returns true when login contains dependabot', () => {
+    expect(isDependabotAuthor(basePr({ user: { login: 'dependabot[bot]' } }))).toBe(true);
+    expect(isDependabotAuthor(basePr({ user: { login: 'DependaBot-test' } }))).toBe(true);
+  });
+
+  test('returns false otherwise', () => {
+    expect(isDependabotAuthor(basePr({ user: { login: 'renovate[bot]' } }))).toBe(false);
+  });
+});
+
+describe('validateDependabotOpenPr', () => {
+  test('returns one alert for open Dependabot PR', () => {
+    const alerts = validateDependabotOpenPr(basePr(), 'o', 'r');
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].checkType).toBe('dependabot_open_pr');
+    expect(alerts[0].title).toBe('pr:1');
+    expect(alerts[0].severity).toBe('low');
+  });
+
+  test('returns empty when PR is closed', () => {
+    expect(validateDependabotOpenPr(basePr({ state: 'closed' }), 'o', 'r')).toHaveLength(0);
+  });
+
+  test('returns empty when author is not Dependabot', () => {
+    expect(
+      validateDependabotOpenPr(basePr({ user: { login: 'human' } }), 'o', 'r')
+    ).toHaveLength(0);
+  });
+});

--- a/frontend/src/constants/table.ts
+++ b/frontend/src/constants/table.ts
@@ -34,6 +34,9 @@ export const CHECK_TYPE_COLUMNS = [
   // PR ↔ issue link (scheduled check only)
   { label: 'Not Linked PR', key: 'notLinkedPr', tagSeverity: 'info' },
 
+  // Dependabot open PRs (author login contains "dependabot")
+  { label: 'Dependabot', key: 'dependabot', tagSeverity: 'info' },
+
   // Test/Performance category - testing and performance issues
   { label: 'Test', key: 'test', tagSeverity: 'info' },
 ] as const;
@@ -89,6 +92,8 @@ export const CHECK_TYPE_MAPPING = {
   ],
 
   notLinkedPr: ['pr_issue_not_linked'],
+
+  dependabot: ['dependabot_open_pr'],
 
   // Test/Performance category
   test: [

--- a/frontend/src/types/alerts.ts
+++ b/frontend/src/types/alerts.ts
@@ -97,6 +97,12 @@ export const checkTypeLabels: Record<string, string> = {
   pull_request_format_violation: 'Pull Request Format Violation',
   pr_review_workflow_missing: 'PR Review Workflow Missing',
   release_labeling_workflow_missing: 'Release Labeling Workflow Missing',
+
+  // PR quality / linkage
+  pr_issue_not_linked: 'PR Not Linked to Issue',
+  pr_missing_evidence: 'PR Missing Evidence',
+  pr_unclear_changes: 'PR Unclear Changes',
+  dependabot_open_pr: 'Dependabot Open PR',
 };
 
 // Component Props Types


### PR DESCRIPTION
## 概要
Closes #192

Dependabot が作成した **オープン** PR の件数を `dependabot_open_pr` として保持し、Check Type-based view に **Dependabot** 列を追加します。

## 仕様
- 対象: `user.login` に `dependabot` を含む（大小無視）、かつ `state === open`
- 定期実行・手動チェックの両方で検出
- マージ/クローズ後は次回チェックで未再検出となり、既存の PR 品質アラートと同様に system resolved

## 変更ファイル
- バックエンド: `checkPullRequests` / `validators` / `alertService` / PR `state` マッピング
- フロント: `CHECK_TYPE_COLUMNS` / `CHECK_TYPE_MAPPING` / `checkTypeLabels`
- テスト: `validators.test.ts`