### PR TITLE
feat(frontend): HTML document titles (Github Health Checker) — closes #199

### DIFF
--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -10,30 +10,30 @@ function createSequelizeInstance(): Sequelize {
     return sequelize;
   }
 
-  const DB_NAME = process.env.DB_NAME as string;
-  const DB_USER = process.env.DB_USER as string;
-  const DB_PASSWORD = process.env.DB_PASSWORD as string;
-  const DB_HOST = process.env.DB_HOST || '127.0.0.1';
-  const DB_PORT = Number(process.env.DB_PORT) || 3306;
-  const DB_CLIENT = process.env.DB_CLIENT || 'mysql'; // 'mysql' | 'postgres' | 'sqlite3'
-  const TZ = process.env.TZ || '+09:00';
+  const dbName = process.env.DB_NAME as string;
+  const dbUser = process.env.DB_USER as string;
+  const dbPassword = process.env.DB_PASSWORD as string;
+  const dbHost = process.env.DB_HOST || '127.0.0.1';
+  const dbPort = Number(process.env.DB_PORT) || 3306;
+  const dbClient = process.env.DB_CLIENT || 'mysql'; // 'mysql' | 'postgres' | 'sqlite3'
+  const tz = process.env.TZ || '+09:00';
 
-  process.env.TZ = TZ;
+  process.env.TZ = tz;
 
-  console.log(`[Database] Creating Sequelize instance with DB_USER: ${DB_USER}, DB_HOST: ${DB_HOST}, DB_NAME: ${DB_NAME}`);
+  console.log(`[Database] Creating Sequelize instance with DB_USER: ${dbUser}, DB_HOST: ${dbHost}, DB_NAME: ${dbName}`);
 
-  if (DB_CLIENT === 'sqlite3') {
+  if (dbClient === 'sqlite3') {
     sequelize = new Sequelize({
       dialect: 'sqlite',
       storage: process.env.DB_FILE === ':memory:' ? ':memory:' : path.resolve(__dirname, process.env.DB_FILE || 'database.sqlite'),
       logging: false,
     });
-  } else if (DB_CLIENT === 'postgres') {
-    sequelize = new Sequelize(DB_NAME, DB_USER, DB_PASSWORD, {
-      host: DB_HOST,
-      port: DB_PORT || 5432,
+  } else if (dbClient === 'postgres') {
+    sequelize = new Sequelize(dbName, dbUser, dbPassword, {
+      host: dbHost,
+      port: dbPort || 5432,
       dialect: 'postgres',
-      timezone: TZ,
+      timezone: tz,
       pool: {
         max: 10,
         min: 0,
@@ -44,11 +44,11 @@ function createSequelizeInstance(): Sequelize {
     });
   } else {
     // default: mysql
-    sequelize = new Sequelize(DB_NAME, DB_USER, DB_PASSWORD, {
-      host: DB_HOST,
-      port: DB_PORT,
+    sequelize = new Sequelize(dbName, dbUser, dbPassword, {
+      host: dbHost,
+      port: dbPort,
       dialect: 'mysql',
-      timezone: TZ,
+      timezone: tz,
       pool: {
         max: 10,
         min: 0,

--- a/backend/src/domain/alert/util/checkPullRequests/github.ts
+++ b/backend/src/domain/alert/util/checkPullRequests/github.ts
@@ -2,6 +2,7 @@
  * GitHub API operations for pull request data
  */
 import { Octokit } from '@octokit/rest';
+import type { RestEndpointMethodTypes } from '@octokit/rest';
 import { subDays } from 'date-fns';
 import { GitHubPullRequest } from './types';
 
@@ -12,17 +13,11 @@ const octokit = new Octokit({
   auth: githubToken,
 });
 
-function mapRestPullRequest(pr: {
-  number: number;
-  title: string;
-  body: string | null;
-  user: { login?: string | null } | null;
-  head: { ref: string };
-  html_url: string;
-  created_at: string;
-  updated_at: string;
-  state: string;
-}): GitHubPullRequest {
+type RestPullFromApi =
+  | RestEndpointMethodTypes['pulls']['list']['response']['data'][number]
+  | RestEndpointMethodTypes['pulls']['get']['response']['data'];
+
+function mapRestPullRequest(pr: RestPullFromApi): GitHubPullRequest {
   return {
     number: pr.number,
     title: pr.title,
@@ -33,9 +28,9 @@ function mapRestPullRequest(pr: {
     head: {
       ref: pr.head.ref,
     },
-    html_url: pr.html_url,
-    created_at: pr.created_at,
-    updated_at: pr.updated_at,
+    htmlUrl: pr.html_url,
+    createdAt: pr.created_at,
+    updatedAt: pr.updated_at,
     state: pr.state === 'closed' ? 'closed' : 'open',
   };
 }
@@ -47,6 +42,7 @@ export async function fetchOpenPullRequests(owner: string, repo: string): Promis
   console.log(`  Fetching open pull requests for ${owner}/${repo}...`);
 
   try {
+    /* eslint-disable @typescript-eslint/naming-convention -- GitHub REST query/body keys (per_page) */
     const response = await octokit.pulls.list({
       owner,
       repo,
@@ -55,6 +51,7 @@ export async function fetchOpenPullRequests(owner: string, repo: string): Promis
       direction: 'desc',
       per_page: 100, // GitHub API limit
     });
+    /* eslint-enable @typescript-eslint/naming-convention */
 
     const pullRequests: GitHubPullRequest[] = response.data.map(mapRestPullRequest);
 
@@ -84,6 +81,7 @@ export async function fetchRecentlyClosedPullRequestsCreatedWithin(
 
   try {
     while (true) {
+      /* eslint-disable @typescript-eslint/naming-convention -- GitHub REST query keys */
       const response = await octokit.pulls.list({
         owner,
         repo,
@@ -93,6 +91,7 @@ export async function fetchRecentlyClosedPullRequestsCreatedWithin(
         per_page: perPage,
         page,
       });
+      /* eslint-enable @typescript-eslint/naming-convention */
 
       if (response.data.length === 0) {
         break;
@@ -183,11 +182,13 @@ export async function getClosingIssuesReferenceCount(owner: string, repo: string
  */
 export async function getPullRequestDetails(owner: string, repo: string, prNumber: number): Promise<GitHubPullRequest | null> {
   try {
+    /* eslint-disable @typescript-eslint/naming-convention -- GitHub REST path/body keys */
     const response = await octokit.pulls.get({
       owner,
       repo,
       pull_number: prNumber,
     });
+    /* eslint-enable @typescript-eslint/naming-convention */
 
     const pr = response.data;
     return mapRestPullRequest(pr);

--- a/backend/src/domain/alert/util/checkPullRequests/types.ts
+++ b/backend/src/domain/alert/util/checkPullRequests/types.ts
@@ -12,9 +12,9 @@ export interface GitHubPullRequest {
   head: {
     ref: string;
   };
-  html_url: string;
-  created_at: string;
-  updated_at: string;
+  htmlUrl: string;
+  createdAt: string;
+  updatedAt: string;
   /** REST API `state` — required for open-only checks when mixing open + closed PR lists */
   state: 'open' | 'closed';
 }

--- a/backend/src/domain/alert/util/checkPullRequests/validators.ts
+++ b/backend/src/domain/alert/util/checkPullRequests/validators.ts
@@ -28,7 +28,7 @@ function createAlert(
     lineNumber: -1,
     codeSnippet: '',
     branch: pr.head.ref,
-    issueUrl: pr.html_url,
+    issueUrl: pr.htmlUrl,
   };
 }
 

--- a/backend/tests/unit/domain/alert/util/checkPullRequests/validators.test.ts
+++ b/backend/tests/unit/domain/alert/util/checkPullRequests/validators.test.ts
@@ -15,9 +15,9 @@ function basePr(overrides: Partial<GitHubPullRequest> = {}): GitHubPullRequest {
     body: 'body',
     user: { login: 'dependabot[bot]' },
     head: { ref: 'dependabot/npm-foo' },
-    html_url: 'https://github.com/o/r/pull/1',
-    created_at: '2025-01-01T00:00:00Z',
-    updated_at: '2025-01-01T00:00:00Z',
+    htmlUrl: 'https://github.com/o/r/pull/1',
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
     state: 'open',
     ...overrides,
   };

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -16,6 +16,12 @@ export default defineNuxtConfig({
   css: ["primeicons/primeicons.css"],
   ssr: false,
 
+  app: {
+    head: {
+      title: "Github Health Checker",
+    },
+  },
+
   primevue: {
     options: {
       theme: {

--- a/frontend/src/composables/useAlertsTabs.ts
+++ b/frontend/src/composables/useAlertsTabs.ts
@@ -6,7 +6,7 @@ type AlertsTabValue = 'active' | 'resolved';
 interface TabState {
   sortField?: string;
   sortOrder?: 'asc' | 'desc';
-  filters?: Record<string, any>;
+  filters?: Record<string, unknown>;
   currentPage?: number;
   pageSize?: number;
 }

--- a/frontend/src/pages/[...slug].vue
+++ b/frontend/src/pages/[...slug].vue
@@ -145,6 +145,14 @@ const toast = useCustomToast();
 // Use route params composable
 const { owner, repo, hasValidParams } = useRouteParams();
 
+useHead({
+  title: computed(() =>
+    owner.value && repo.value
+      ? `${owner.value}/${repo.value} · Github Health Checker`
+      : 'Github Health Checker'
+  ),
+});
+
 // Use the alerts composable
 const {
   loading,

--- a/frontend/src/pages/authors/[author].vue
+++ b/frontend/src/pages/authors/[author].vue
@@ -290,9 +290,8 @@ onMounted(() => {
   fetchData();
 });
 
-// Set page title
 useHead({
-  title: `${author} - Author Details`,
+  title: `${author} · Github Health Checker`,
 });
 </script>
 

--- a/frontend/src/pages/index.vue
+++ b/frontend/src/pages/index.vue
@@ -73,6 +73,10 @@
 
 <script setup lang="ts">
 import { onMounted, computed } from 'vue';
+
+useHead({
+  title: 'Dashboard · Github Health Checker',
+});
 import { useRepoHealth } from '@/composables/useRepoHealth';
 import { useCheckTypeAlerts } from '@/composables/useCheckTypeAlerts';
 import { useTabState } from '@/composables/useTabState';

--- a/frontend/src/pages/test-env.vue
+++ b/frontend/src/pages/test-env.vue
@@ -39,6 +39,10 @@
 import { ref, computed } from 'vue'
 import { useApiConfig } from '~/composables/useApiConfig'
 
+useHead({
+  title: '環境変数テスト · Github Health Checker',
+})
+
 const { apiBaseUrl: computedApiBaseUrl } = useApiConfig()
 
 // 環境変数の値を直接取得

--- a/frontend/src/types/alerts.ts
+++ b/frontend/src/types/alerts.ts
@@ -43,7 +43,7 @@ export interface PaginationState {
 export interface TabState {
   sortField?: string;
   sortOrder?: 'asc' | 'desc';
-  filters?: Record<string, any>;
+  filters?: Record<string, unknown>;
   currentPage?: number;
   pageSize?: number;
 }


### PR DESCRIPTION
## Summary
Closes #199.

- Set default `app.head.title` in Nuxt (`Github Health Checker`, per README).
- Per-route titles via `useHead` for dashboard, repository alerts (`owner/repo`), author page, and env test page.
- ESLint: database env var locals use camelCase; `GitHubPullRequest` uses camelCase with Octokit-typed mapping; frontend `Record<string, unknown>` for tab filters.

## Verification
- `yarn lint` (frontend + backend)
- `yarn build` (frontend)
- `npx tsc --noEmit` (backend)