### PR TITLE
chore(ci): bump GitHub Actions (checkout, setup-node, github-script)

### DIFF
--- a/.github/workflows/create-dependency-issues.yml
+++ b/.github/workflows/create-dependency-issues.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Create issues from open Dependabot PRs
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/lint-backend.yml
+++ b/.github/workflows/lint-backend.yml
@@ -12,8 +12,8 @@ jobs:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: yarn

--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -12,8 +12,8 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: yarn

--- a/.github/workflows/pr-policy-check.yml
+++ b/.github/workflows/pr-policy-check.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout base repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/release-labeling.yaml
+++ b/.github/workflows/release-labeling.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Label linked issues based on target branch
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const prNumber = context.payload.pull_request.number;


### PR DESCRIPTION
## Summary

Implements the dependency updates from [Issue #240](https://github.com/TeckVeho/health-checker/issues/240) in a single change, superseding the open Dependabot PRs:

- `actions/checkout` **v4 → v6** (#210)
- `actions/setup-node` **v4 → v6** (#211)
- `actions/github-script` **v7/v8 → v9** (#212)

## Files

- `lint-frontend.yml` / `lint-backend.yml`: checkout + setup-node
- `pr-policy-check.yml`: checkout + github-script
- `create-dependency-issues.yml`: github-script
- `release-labeling.yaml`: github-script (was v8)

## Verification (local)

- `backend`: `yarn lint` ✓, `yarn build` ✓
- `frontend`: `yarn lint` ✓
- `yarn test:unit` / `yarn test:run` show existing failures unrelated to this CI-only change

## After merge

- Close or decline Dependabot PRs #210, #211, #212 as superseded (optional: close #240 with this PR).

Closes #240