### PR TITLE
fix(test): BE ユニットテストの修正 (closes #246)

### DIFF
--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -7,6 +7,8 @@ const config: Config = {
   collectCoverage: true,
   coverageDirectory: 'coverage',
   moduleFileExtensions: ['ts', 'js'],
+  // tsc 出力 dist が残っていると手動モック等が二重解決されうる
+  modulePathIgnorePatterns: ['<rootDir>/dist/'],
   testMatch: [
     '<rootDir>/tests/**/*.test.ts',
     '<rootDir>/src/**/*.test.ts',
@@ -22,13 +24,12 @@ const config: Config = {
     '@utils/(.*)': '<rootDir>/src/utils/$1',
     '@config/(.*)': '<rootDir>/src/config/$1',
     '@routes/(.*)': '<rootDir>/src/routes/$1',
-    '^@octokit/rest$': '<rootDir>/tests/__mocks__/@octokit/rest.js',
   },
   transform: {
     '^.+\\.ts$': [
       'ts-jest',
       {
-        useESM: true, 
+        useESM: true,
       },
     ],
   },

--- a/backend/src/domain/alert/util/checkIssues/index.ts
+++ b/backend/src/domain/alert/util/checkIssues/index.ts
@@ -62,7 +62,7 @@ export async function checkIssues(
 
       // Skip issues with specific labels (these issues don't have SP/deadlines or are out of scope)
       const skipLabels = ['parent', 'bug'];
-      const hasSkipLabel = issue.labels.some((label) =>
+      const hasSkipLabel = (issue.labels ?? []).some((label) =>
         skipLabels.includes(String(label.name || '').toLowerCase())
       );
       if (hasSkipLabel) {

--- a/backend/src/domain/alert/util/checkIssues/validators.ts
+++ b/backend/src/domain/alert/util/checkIssues/validators.ts
@@ -89,17 +89,19 @@ export function validateStoryPoints(
       `Issue #${issue.number} has no Story Point assigned.`,
       'low'
     ));
-  } /*else if (storyPoints > 8) {
+  } else if (storyPoints > 8) {
     // SP greater than 8 (possibly overestimated)
-    alerts.push(createAlert(
-      issue,
-      owner,
-      repo,
-      'issue_large_sp',
-      `Issue #${issue.number} has Story Point ${storyPoints} which is greater than 8 (possibly overestimated).`,
-      'low'
-    ));
-  }*/
+    alerts.push(
+      createAlert(
+        issue,
+        owner,
+        repo,
+        'issue_large_sp',
+        `Issue #${issue.number} has Story Point ${storyPoints} which is greater than 8 (possibly overestimated).`,
+        'low'
+      )
+    );
+  }
 
   return alerts;
 }

--- a/backend/tests/setup/env.ts
+++ b/backend/tests/setup/env.ts
@@ -5,10 +5,9 @@ process.env.OPENAI_API_KEY = 'test-dummy-openai-key';
 process.env.TZ = '+09:00';
 process.env.GITHUB_LOCAL_WORKSPACE = '/tmp/test-workspace';
 
-// データベースを使わないようにモック化
-jest.mock('../../src/config/database', () => ({
-  __esModule: true,
-  default: {
+// データベースを使わないようにモック化（default は createSequelizeInstance ファクトリ）
+jest.mock('../../src/config/database', () => {
+  const mockSequelize = {
     sync: jest.fn().mockResolvedValue(undefined),
     close: jest.fn().mockResolvedValue(undefined),
     authenticate: jest.fn().mockResolvedValue(undefined),
@@ -23,8 +22,14 @@ jest.mock('../../src/config/database', () => ({
       count: jest.fn().mockResolvedValue(0),
       aggregate: jest.fn().mockResolvedValue(0),
     }),
-  },
-}));
+  };
+  const createSequelizeInstance = jest.fn(() => mockSequelize);
+  return {
+    __esModule: true,
+    default: createSequelizeInstance,
+    createSequelizeInstance,
+  };
+});
 
 // Sequelizeモデルをモック化
 jest.mock('sequelize', () => {

--- a/backend/tests/unit/domain/alert/alertController.test.ts
+++ b/backend/tests/unit/domain/alert/alertController.test.ts
@@ -4,14 +4,15 @@ import AlertService from '../../../../src/domain/alert/alertService';
 import getMessage from '../../../../src/utils/message';
 
 // Mock database configuration to prevent connection attempts
-jest.mock('../../../../src/config/database', () => ({
-  __esModule: true,
-  default: {
+jest.mock('../../../../src/config/database', () => {
+  const mockSequelize = {
     sync: jest.fn().mockResolvedValue(undefined),
     close: jest.fn().mockResolvedValue(undefined),
     authenticate: jest.fn().mockResolvedValue(undefined),
-  },
-}));
+  };
+  const createSequelizeInstance = jest.fn(() => mockSequelize);
+  return { __esModule: true, default: createSequelizeInstance, createSequelizeInstance };
+});
 
 // Mock dependencies
 jest.mock('../../../../src/domain/alert/alertService');

--- a/backend/tests/unit/domain/alert/alertService.test.ts
+++ b/backend/tests/unit/domain/alert/alertService.test.ts
@@ -42,12 +42,11 @@ jest.mock('@ai-sdk/openai', () => ({
 }));
 
 // Mock database configuration
-jest.mock('../../../../src/config/database', () => ({
-  __esModule: true,
-  default: {
-    query: jest.fn(),
-  },
-}));
+jest.mock('../../../../src/config/database', () => {
+  const mockSequelize = { query: jest.fn() };
+  const createSequelizeInstance = jest.fn(() => mockSequelize);
+  return { __esModule: true, default: createSequelizeInstance, createSequelizeInstance };
+});
 
 // Mock alert schema
 jest.mock('../../../../src/domain/alert/alertSchema', () => ({
@@ -55,32 +54,20 @@ jest.mock('../../../../src/domain/alert/alertSchema', () => ({
   alertModelOptions: {},
 }));
 
-// Mock Alert model
-const mockAlert = {
-  findOrCreate: jest.fn(),
-  update: jest.fn(),
-};
-
-jest.mock('sequelize', () => {
-  const originalModule = jest.requireActual('sequelize');
-  return {
-    ...originalModule,
-    Model: jest.fn().mockImplementation(() => mockAlert),
-  };
-});
-
 jest.mock('../../../../src/domain/repo/repoSchema', () => ({
   repoAttributes: {},
   repoModelOptions: {},
 }));
 
-// Mock Sequelize with proper Model class
+// Mock Sequelize（2 重定義をやめ、Alert.update 等 static を揃える）
 jest.mock('sequelize', () => ({
   Model: class MockModel {
     static init = jest.fn();
     static findOrCreate = jest.fn();
     static findAll = jest.fn();
     static findOne = jest.fn();
+    static update = jest.fn().mockResolvedValue([0, []]);
+    static count = jest.fn().mockResolvedValue(0);
   },
   QueryTypes: { SELECT: 'SELECT' },
   Op: { gte: 'gte' },

--- a/backend/tests/unit/domain/alert/auditScanner.test.ts
+++ b/backend/tests/unit/domain/alert/auditScanner.test.ts
@@ -29,17 +29,18 @@ jest.mock('sequelize', () => {
 });
 
 // Mock database config
-jest.mock('../../../../src/config/database', () => ({
-  __esModule: true,
-  default: {
+jest.mock('../../../../src/config/database', () => {
+  const mockSequelize = {
     authenticate: jest.fn(),
     close: jest.fn(),
     define: jest.fn(),
     sync: jest.fn(),
     transaction: jest.fn(),
     query: jest.fn(),
-  },
-}));
+  };
+  const createSequelizeInstance = jest.fn(() => mockSequelize);
+  return { __esModule: true, default: createSequelizeInstance, createSequelizeInstance };
+});
 
 jest.mock('child_process', () => ({
   exec: jest.fn(),

--- a/backend/tests/unit/domain/alert/checkActions.test.ts
+++ b/backend/tests/unit/domain/alert/checkActions.test.ts
@@ -39,17 +39,18 @@ jest.mock('sequelize', () => {
 });
 
 // Mock database config
-jest.mock('../../../../src/config/database', () => ({
-  __esModule: true,
-  default: {
+jest.mock('../../../../src/config/database', () => {
+  const mockSequelize = {
     authenticate: jest.fn(),
     close: jest.fn(),
     define: jest.fn(),
     sync: jest.fn(),
     transaction: jest.fn(),
     query: jest.fn(),
-  },
-}));
+  };
+  const createSequelizeInstance = jest.fn(() => mockSequelize);
+  return { __esModule: true, default: createSequelizeInstance, createSequelizeInstance };
+});
 
 // Mock Octokit
 const mockOctokit = {

--- a/backend/tests/unit/domain/alert/checkIssues.test.ts
+++ b/backend/tests/unit/domain/alert/checkIssues.test.ts
@@ -11,6 +11,7 @@ const mockOctokit = {
 };
 
 jest.mock('@octokit/rest', () => ({
+  __esModule: true,
   Octokit: jest.fn().mockImplementation(() => mockOctokit),
 }));
 

--- a/backend/tests/unit/domain/alert/util/gitleaksScanner.test.ts
+++ b/backend/tests/unit/domain/alert/util/gitleaksScanner.test.ts
@@ -9,8 +9,15 @@ jest.mock('../../../../../src/domain/alert/alertService', () => ({
   resolveUndetectedAlerts: jest.fn().mockResolvedValue(undefined),
 }));
 
-// Mock the database
-jest.mock('../../../../../src/config/database', () => ({}));
+// Mock the database (default export must be createSequelizeInstance)
+jest.mock('../../../../../src/config/database', () => {
+  const mockSequelize = {
+    sync: jest.fn().mockResolvedValue(undefined),
+    define: jest.fn().mockReturnValue({}),
+  };
+  const createSequelizeInstance = jest.fn(() => mockSequelize);
+  return { __esModule: true, default: createSequelizeInstance, createSequelizeInstance };
+});
 
 describe('GitleaksScanner', () => {
   const testWorkspace = path.join(__dirname, 'test-workspace');


### PR DESCRIPTION
## 概要

[Issue #246](https://github.com/TeckVeho/health-checker/issues/246) に対応し、`backend` の `npm run test:unit` が通るようにしました。

## 変更内容

- **checkIssues**: `issue.labels` が未取得の issue でも落ちないよう `(issue.labels ?? []).some(...)` に変更
- **validators**: コメントアウトされていた `issue_large_sp`（SP > 8）の検出を再度有効化
- **テスト用 DB モック**: `createSequelizeInstance` を default から呼べるようファクトリ形に統一
- **alertService.test**: 重複した `jest.mock(sequelize)` を整理し `Alert.update` 用の static を追加
- **Jest**: `dist/` を `modulePathIgnorePatterns` に追加、`@octokit/rest` の moduleNameMapper を削除

## 検証

- `cd backend && npm run test:unit`（29 suites / 431 tests すべて成功）

Closes #246