### PR TITLE
fix(frontend): align unit tests with RepoTable and useApiConfig

### DIFF
--- a/frontend/tests/unit/components/Molecules/RepoTable.spec.ts
+++ b/frontend/tests/unit/components/Molecules/RepoTable.spec.ts
@@ -127,8 +127,8 @@ describe('RepoTable', () => {
       });
 
       const columns = wrapper.findAllComponents({ name: 'Column' });
-      // 3 default columns (name, description, totalViolations) + 3 custom columns
-      expect(columns.length).toBeGreaterThanOrEqual(6);
+      // Repository + Total defaults + severity columns from props (mockColumns length 3)
+      expect(columns.length).toBeGreaterThanOrEqual(5);
     });
 
     it('should render repository name column', () => {
@@ -372,8 +372,8 @@ describe('RepoTable', () => {
       });
 
       const columns = wrapper.findAllComponents({ name: 'Column' });
-      // Should still have the default columns (name, description, totalViolations)
-      expect(columns.length).toBe(3);
+      // Default columns: Repository (name), Total violations only when columns prop is empty
+      expect(columns.length).toBe(2);
     });
   });
 

--- a/frontend/tests/unit/composables/useApiConfig.spec.ts
+++ b/frontend/tests/unit/composables/useApiConfig.spec.ts
@@ -173,17 +173,18 @@ describe('useApiConfig', () => {
         primevue: { options: { theme: { preset: {} } } }
       }
       
+      // No window SSR / non-browser production: fallback must not mask missing config
+      const originalWindow = global.window
+      delete (global as any).window
+
       const { apiBaseUrl } = useApiConfig()
       
       // Should throw error in production when no config is available
-      expect(() => apiBaseUrl.value).toThrow('API configuration not found. Please check your environment variables.')
+      expect(() => apiBaseUrl.value).toThrow('NUXT_PUBLIC_API_BASE_URL environment variable is not set')
       
       // Restore original values
       process.env.NODE_ENV = originalNodeEnv
-      Object.defineProperty(window, 'location', {
-        value: originalLocation,
-        writable: true
-      })
+      global.window = originalWindow
       process.env.NUXT_PUBLIC_API_BASE_URL = originalNuxtPublicApiBaseUrl
     })
   })


### PR DESCRIPTION
Align RepoTable specs with columns (Repository + Total + dynamic). Adjust useApiConfig production test by removing `window` for SSR parity.

Fixes #254